### PR TITLE
CORS configuration for separate testing URL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,5 @@ dist
 
 # TernJS port file
 .tern-port
+public2/.DS_Store
+.DS_Store

--- a/src/client_comms.js
+++ b/src/client_comms.js
@@ -4,7 +4,7 @@
  */
 
 'use strict'
-
+const RQ_PARAMS = require('./params.js')
 const { Server } = require('socket.io')
 
 const PING_INTERVAL_MS = 25000
@@ -40,7 +40,7 @@ class ClientComms {
       expressServer,
       {
         cors: {
-          origin: 'http://127.0.0.1:8080', // Replace with your actual client's origin
+          origin: RQ_PARAMS.EXTERNAL_UI_ORIGIN,
           methods: ['GET', 'POST']
         },
         pingInterval: PING_INTERVAL,

--- a/src/client_comms.js
+++ b/src/client_comms.js
@@ -39,6 +39,10 @@ class ClientComms {
     this.io = new Server(
       expressServer,
       {
+        cors: {
+          origin: 'http://127.0.0.1:8080', // Replace with your actual client's origin
+          methods: ['GET', 'POST']
+        },
         pingInterval: PING_INTERVAL,
         pingTimeout: SOCKET_PING_TIMEOUT_S * 60
       }

--- a/src/params.js
+++ b/src/params.js
@@ -17,5 +17,6 @@ RQ_PARAMS.PERSIST_DIR = path.join(
   __dirname, '../public/persist')
 RQ_PARAMS.SERVER_PORT_NUMBER = 3456
 RQ_PARAMS.SERVER_HEARTBEAT_PERIOD_S = 10
+RQ_PARAMS.EXTERNAL_UI_ORIGIN = 'http://127.0.0.1:8080'
 
 module.exports = RQ_PARAMS


### PR DESCRIPTION
For development use, create a cors allowance for a UI to be separate from the robot at 127.0.0.1:8080, whatever is specified can use the socket from the robot without being on the raspberry pi,

The parameter must be changed before the NodeJS server can be deployed for production use.