### PR TITLE
Cleanup console.log output and profile camera frames

### DIFF
--- a/public/js/rq_testing.js
+++ b/public/js/rq_testing.js
@@ -175,23 +175,12 @@ class RQTesting {
    *
    */
   setupSocketEvents () {
-    this.socket.add_event('hb', this.heartbeat_cb.bind(this))
     this.socket.add_event('mainImage', this.image_cb.bind(this))
 
     // TODO: Enhance this to instead use this.subscriptionDataMap
     this.socket.add_event('telemetry', this.telemetry_cb.bind(this))
 
     console.log('setupSocketEvents')
-  }
-
-  /**
-   * Receive the heartbeat event from the server and update
-   * the UI.
-   *
-   * @param {int} payload - the millisecond timestamp of the heartbeat.
-   */
-  heartbeat_cb (payload) {
-    console.log(`hb event received: ${payload}`)
   }
 
   /**
@@ -298,18 +287,6 @@ class RQTesting {
   }
 
   /**
-   * Send a heartbeat to the robot.
-   *
-   */
-  send_heartbeat () {
-    if (this.robotConnected) {
-      this.socket.send_event('hb', Date.now().toString())
-    } else {
-      console.log('Heartbeat not sent because robot not connected')
-    }
-  }
-
-  /**
    * Control visibility of the message widget and set its text.
    *
    * @param {string} text - The message to display.
@@ -352,5 +329,3 @@ class RQTesting {
 } // RQTesting
 
 const rqTesting = new RQTesting()
-
-setInterval(rqTesting.send_heartbeat.bind(rqTesting), 10000)

--- a/src/client_comms.js
+++ b/src/client_comms.js
@@ -64,7 +64,7 @@ class ClientComms {
    * Called each time a client connects to the socket. Sets the
    * handlers for events received from the browser-side.
    *
-   * disconnect and hb events are always handled. this.incoming_events
+   * disconnect events are always handled. this.incoming_events
    * is interpreted as a list of events to also handle, by passing
    * their name and payload to this.eventCb.
    */
@@ -78,14 +78,6 @@ class ClientComms {
         console.log('Socket disconnected: ' + this.socket.id + ', Reason: ' + reason)
         this.socket = null
       })
-
-    this.socket.on(
-      'hb',
-      payload => {
-        // TODO: Do something useful with this info
-        console.log(`Client heartbeat payload ${payload}`)
-      }
-    )
 
     this.incomingEvents.forEach(this.add_event_handler.bind(this))
 
@@ -110,15 +102,6 @@ class ClientComms {
     }
 
     return false
-  }
-
-  /**
-   * Sends heartbeat events to the client.
-   */
-  heartbeat () {
-    if (!this.send_event('hb', Date.now().toString())) {
-      console.log('Heartbeat not sent. No client.')
-    }
   }
 }
 

--- a/src/rq_server.js
+++ b/src/rq_server.js
@@ -5,7 +5,6 @@
  * WebServer and RobotComms and then acts as the broker between them.
  */
 
-const RQ_PARAMS = require('./params.js')
 const ConfigFile = require('./config_file.js')
 const configFile = new ConfigFile()
 
@@ -44,9 +43,5 @@ webServer.setup_send_to_robot((eventName, payload) => {
  * given to the web server, actually start it.
  */
 webServer.setup_client_comms()
-
-setInterval(
-  webServer.send_heartbeat.bind(webServer),
-  RQ_PARAMS.SERVER_HEARTBEAT_PERIOD_S * 1000)
 
 robotComms.main()

--- a/src/web_server.js
+++ b/src/web_server.js
@@ -179,10 +179,6 @@ class WebServer {
 
     process.exit(1)
   }
-
-  send_heartbeat () {
-    this.#client.heartbeat()
-  }
 }
 
 module.exports = WebServer


### PR DESCRIPTION
This will be roboquest_ui v 13.

Removed the transmission of application-level hearbeat events over the socket, to declutter the console.log output and reduce the traffic on the socket. Now relying instead on the socket.io ping and timeout mechanisms.

With the RaspPi and the browser host connected to the same wired network, camera FPS was 34 and network traffic was around 30 Mbps steady. On a Linux notebook, the rate was 32 FPS and network traffic was between 30 and 36 Mbps. Also, notebook browser showed random noise in the image as horizontal white lines. Did not investigate the cause. Connecting the notebook to house WiFi and using the RaspPi's wired network, the noise was not present and frames were 34 FPS steadily.
