### PR TITLE
Added profiling of camera frames

### DIFF
--- a/public/js/rq_testing.js
+++ b/public/js/rq_testing.js
@@ -5,6 +5,8 @@
  */
 'use strict'
 
+const FRAMES_PER_CYCLE = 1000
+
 class RQTesting {
   /**
    * Setup the class.
@@ -17,6 +19,8 @@ class RQTesting {
     this.subscriptionDataMap = null
     this.cameraFrames = document.getElementById('mainImage')
     this.pageBuilt = false
+    this.framesReceived = 0
+    this.framesStartTimestamp = Date.now()
     this.getConfiguration(
       buildPage,
       this.mapSubscriptionData.bind(this),
@@ -197,6 +201,15 @@ class RQTesting {
    * and https://developer.mozilla.org/en-US/docs/Glossary/Base64
    */
   image_cb (jpegImage) {
+    this.framesReceived++
+    if (this.framesReceived > FRAMES_PER_CYCLE) {
+      const fps = (this.framesReceived /
+        (Date.now() - this.framesStartTimestamp) * 1000)
+      console.log(`Camera FPS: ${fps}`)
+      this.framesReceived = 0
+      this.framesStartTimestamp = Date.now()
+    }
+
     let jpegImageStr = ''
     const jpegImageBuffer = new Uint8Array(jpegImage)
     for (let i = 0; i < jpegImageBuffer.byteLength; i++) {


### PR DESCRIPTION
Calculate the camera FPS received at the browser and display the result periodically using console.log.

With the RaspPi and the browser host connected to the same wired network, camera FPS was 34 and network traffic was around 30 Mbps steady. On a Linux notebook, the rate was 32 FPS and network traffic was between 30 and 36 Mbps. Also, notebook browser showed random noise in the image as horizontal white lines. Did not investigate the cause. Connecting the notebook to house WiFi and using the RaspPi's wired network, the noise was not present and frames were 34 FPS steadily.