### PR TITLE
v13: Removed the check for a "config" property in the configuration file

### DIFF
--- a/src/web_server.js
+++ b/src/web_server.js
@@ -53,22 +53,26 @@ class WebServer {
     })
 
     this.express_app.post('/config', (request, response) => {
+      const configObject = request.body
+
       /*
        * Perform a crude check for a valid configuration file by
-       * ensuring it contains a "widgets" property.
+       * ensuring it contains a "widgets" property. The response.body
+       * is expected to have already been parsed into an object by Express.
        */
-      if (request.body.widgets) {
-        if (this.configFile.save_config(request.body)) {
-          response.status(200).json({ success: true })
-          console.log('process_config_post() success')
-        } else {
-          response.status(400).json(
-            { success: false, error: 'Failed to save the config' })
-          console.log('POST failure, config not saved')
-        }
+      if (!configObject.widgets) {
+        response.status(400).json({ success: false, error: 'config missing widgets property' })
+        console.log(
+          `save_config: no widgets property in the config file ${JSON.stringify(request.body)}`)
+        return
+      }
+
+      if (this.configFile.save_config(configObject)) {
+        response.status(200).json({ success: true })
       } else {
-        response.status(400).json({ success: false, error: 'Missing configuration file' })
-        console.log('POST failure, missing config file')
+        response.status(400).json(
+          { success: false, error: 'Failed to save the config' })
+        console.log('save_config: config not saved')
       }
     })
   }

--- a/src/web_server.js
+++ b/src/web_server.js
@@ -53,7 +53,11 @@ class WebServer {
     })
 
     this.express_app.post('/config', (request, response) => {
-      if (request.body.widgets && request.body.config) {
+      /*
+       * Perform a crude check for a valid configuration file by
+       * ensuring it contains a "widgets" property.
+       */
+      if (request.body.widgets) {
         if (this.configFile.save_config(request.body)) {
           response.status(200).json({ success: true })
           console.log('process_config_post() success')


### PR DESCRIPTION
This will be roboquest_ui v13.

Issue #38 

The WebServer class defines a callback function for saving the configuration file to the persistent file store using the ConfigFile.save_config() method. As a crude means of verifying the validity of the configuration file, it looked for both a widgets and a config property in the file. In v13 of roboquest_ui nothing uses the config section of the configuration and the browser doesn't include it. The check for the config property was therefore removed.

The POST request must include the Content-Type header set to "application/json" and the payload with the request must be the complete configuration as a JSON string.

Tested by starting everything and then using curl.
```
curl -X GET http://server:3456/persist/configuration.json > /tmp/configuration.json
# make a change in /tmp/configuration.json
curl -X POST -H "Content-Type: application/json" -d @/tmp/configuration.json -o /tmp/response -s -w "%{http_code}\n" http://server:3456/config
# remove the widgets property
curl -X POST -H "Content-Type: application/json" -d @/tmp/configuration.json -o /tmp/response -s -w "%{http_code}\n" http://server:3456/config
# check for "version" property at the end of the configuration file
```