### PR TITLE
fix encoding on save config

### DIFF
--- a/public/js/index.js
+++ b/public/js/index.js
@@ -123,6 +123,9 @@ $(function () {
       data: JSON.stringify(objSaveConfig),
       success: function (objResponse) {
         console.log('Save Config Response', objResponse)
+      },
+      error: function(objRequest, strStatus, strError) {
+        console.error("Error saving config:", strError);
       }
     });
   })

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -116,9 +116,15 @@ $(function () {
     $('.widget').each((i, element) => {
       objSaveConfig.widgets.push($(element).data('widget'))
     })
-    $.post('/config', objSaveConfig, function (objResponse) {
-      console.log('Save Config Response', objResponse)
-    })
+    $.ajax({
+      type: "POST",
+      url: '/config',
+      contentType: "application/json",
+      data: JSON.stringify(objSaveConfig),
+      success: function (objResponse) {
+        console.log('Save Config Response', objResponse)
+      }
+    });
   })
 
   // edit corner can add a new widget by clicking or tapping, or edit a widget that is dropped into it


### PR DESCRIPTION
I removed the shortcut for post to have more control and also explicitly set the contentType header + stringily the json

Tested by removing the configuration.json* files from public/persist. Clicked the save config button and confirmed the old config file was moved and a new config file was saved.