### PR TITLE
Corrected the assembly of the event payload for the Slider widget

### DIFF
--- a/public/js/wSlider.js
+++ b/public/js/wSlider.js
@@ -24,10 +24,12 @@ $.widget('custom.SLIDER', {
   },
   _triggerSocketEvent: function (e, ui) {
     if (this.options.socket) {
+      const objPayload = {}
+      objPayload[this.options.data.topicAttribute[0]] = ui.value
+      objPayload[this.options.data.topicAttribute[1]] = this.options.label
       this.options.socket.emit(
         this.options.data.topic,
-        `{ "${this.options.data.topicAttribute[0]}": "${ui.value}"` +
-        `, "${this.options.data.topicAttribute[1]}": "${this.options.label}" }`
+        JSON.stringify(objPayload)
       )
     } else {
       console.error('Socket is not defined.')

--- a/public/js/wSlider.js
+++ b/public/js/wSlider.js
@@ -24,9 +24,11 @@ $.widget('custom.SLIDER', {
   },
   _triggerSocketEvent: function (e, ui) {
     if (this.options.socket) {
-      // const payload = `["${widgetConfig.name}",${event.target.value}]`
-      // console.log('slider value', ui.value)
-      this.options.socket.emit(this.options.data.topic, `["${this.options.data.topicAttribute}":"${ui.value}"]`)
+      this.options.socket.emit(
+        this.options.data.topic,
+        `{ "${this.options.data.topicAttribute[0]}": "${ui.value}"` +
+        `, "${this.options.data.topicAttribute[1]}": "${this.options.label}" }`
+      )
     } else {
       console.error('Socket is not defined.')
     }


### PR DESCRIPTION
The implementation of the Slider widget wasn't emitting a properly formed payload with the 'servos' event. Corrected it to assemble payloads with the format:
```
{ "angle": 178, "name": "camera_pan"}
```

Tested by running rq_core and rq_ui, starting a "ros2 topic echo /servos", enabling the servos, and then wiggling the camera_pan slider. The published messages look like:

```
---                                                                                                 
header:                                                                                             
  stamp:                                                                                            
    sec: 1693338893                                                                                 
    nanosec: 783999919                                                                              
  frame_id: ''                                                                                      
servos:                                                                                             
- name: camera_pan                                                                                  
  angle: 49       
```

There may be other issues with limits on the range of the servo.

This is Issue #56 