### PR TITLE
Renamed the MENU button at the top of the page to CONFIGURE

### DIFF
--- a/public/css/index.css
+++ b/public/css/index.css
@@ -111,7 +111,7 @@ input, select{
     height: 100%;
 }
 /* centered */
-#menu{
+#configure{
     cursor: pointer;
     position: absolute;
     top: 5px;

--- a/public/index.htm
+++ b/public/index.htm
@@ -10,7 +10,7 @@
 </head>
 <body>
     <div id="edit"></div>
-    <div id="menu"> CONFIGURE </div>
+    <div id="configure"> CONFIGURE </div>
     <div id="trash"></div>
     <div id="widgets"></div>
     <img id='mainImage'

--- a/public/index.htm
+++ b/public/index.htm
@@ -10,7 +10,7 @@
 </head>
 <body>
     <div id="edit"></div>
-    <div id="menu"> MENU </div>
+    <div id="menu"> CONFIGURE </div>
     <div id="trash"></div>
     <div id="widgets"></div>
     <img id='mainImage'

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -90,7 +90,7 @@ $(function () {
     }
   })
 
-  // setup the menu
+  // setup the configuration menu
   $('#menuDialog').dialog({
     width: 500,
     autoOpen: false,
@@ -99,7 +99,7 @@ $(function () {
       $('#socketUri').val(objSocket.io.uri)
     }
   })
-  $('#menu').on('click', function () {
+  $('#configure').on('click', function () {
     $('#menuDialog').dialog('open')
   })
   $('#setSocket').on('click', function () {


### PR DESCRIPTION
One of the simplest possible changes and PRs. Changed the text of the id=menu DIV from MENU to CONFIGURE. Also changed the ID from menu to configure for consistency.

Tested by rebuilding, starting, connecting the browser, clicking on the CONFIGURE button and cancelling the Configuration Menu.

This is Issue #36 