### PR TITLE
Added key event control for Button widgets

### DIFF
--- a/public/config/README_configuration.md
+++ b/public/config/README_configuration.md
@@ -179,3 +179,11 @@ the widget properties have the following sections:
                 "upValues": { "name": "Right", "value": 10 } 
               } 
             }
+    (button)
+            "keys": {
+              "190": {
+                "name": "period",
+                "downValues": {}
+              }
+            }
+

--- a/public/config/configuration.json
+++ b/public/config/configuration.json
@@ -218,6 +218,12 @@
                 "serviceAttribute": "set_motors",
                 "serviceType": "rq_msgs/srv/Control",
                 "clickValue": "ON"
+            },
+            "keys": {
+              "190": {
+                "name": "period",
+                "downValues": {}
+              }
             }
         },
         {
@@ -236,6 +242,12 @@
                 "serviceAttribute": "set_motors",
                 "serviceType": "rq_msgs/srv/Control",
                 "clickValue": "OFF"
+            },
+            "keys": {
+              "188": {
+                "name": "comma",
+                "downValues": {}
+              }
             }
         },
         {
@@ -254,6 +266,12 @@
                 "serviceAttribute": "set_servos",
                 "serviceType": "rq_msgs/srv/Control",
                 "clickValue": "ON"
+            },
+            "keys": {
+              "83": {
+                "name": "s",
+                "downValues": {}
+              }
             }
         },
         {
@@ -272,8 +290,15 @@
                 "serviceAttribute": "set_servos",
                 "serviceType": "rq_msgs/srv/Control",
                 "clickValue": "OFF"
+            },
+            "keys": {
+              "65": {
+                "name": "a",
+                "downValues": {}
+              }
             }
-        },{
+        },
+        {
             "id": 18,
             "type": "joystick",
             "label": "Joystick",

--- a/public/js/wButton.js
+++ b/public/js/wButton.js
@@ -1,12 +1,25 @@
-$.widget('custom.BUTTON', {
+'use strict'
+/* global jQuery, RQ_PARAMS */
+
+jQuery.widget(RQ_PARAMS.WIDGET_NAMESPACE + '.BUTTON', {
   options: {
     format: {},
     data: {},
     socket: null
   },
 
+  /**
+   * Called by the key event handler and in turn calls the _triggerSocketEvent
+   * method. In the case of this widgetType, valuesHandler merely calls
+   * _triggerSocketEvent() because a button produces no more data than its
+   * click event.
+   */
+  valuesHandler: function () {
+    this._triggerSocketEvent()
+  },
+
   _create: function () {
-    const buttonElement = $('<div class="widgetButton">').text(this.options.format.text).button().appendTo(this.element)
+    const buttonElement = jQuery('<div class="widgetButton">').text(this.options.format.text).button().appendTo(this.element)
     this.element.children('.widget-content').html(buttonElement)
     buttonElement.on('click', () => {
       this._triggerSocketEvent()
@@ -15,8 +28,10 @@ $.widget('custom.BUTTON', {
 
   _triggerSocketEvent: function () {
     if (this.options.socket) {
-      // console.log(`Emitting ${this.options.data.service} with {${this.options.data.serviceAttribute}:${this.options.data.clickValue}}`)
-      this.options.socket.emit(this.options.data.service, `{"${this.options.data.serviceAttribute}":"${this.options.data.clickValue}"}`)
+      this.options.socket.emit(
+        this.options.data.service,
+        `{"${this.options.data.serviceAttribute}":"${this.options.data.clickValue}"}`
+      )
     } else {
       console.error('Socket is not defined.')
     }


### PR DESCRIPTION
A single key can be assigned to emulate a Button click. The configuration is described in public/config/README_configuration.md. The button uses only the keyDown event and doesn't include any values.

Keys are assigned as follows:

<period> - motors ON
<comma> - motors OFF
s - servos ON
a - servos OFF

To test, start all the application software, click the ENABLE KEYS button. Observe the Motors and Servos indicator while pressing each of the four keys.

Issue #65, related to Issue #64