### PR TITLE
Removed edit square and set socket option

### DIFF
--- a/public/css/index.css
+++ b/public/css/index.css
@@ -210,26 +210,3 @@ input, select{
         0% 10%
     )
 }
-
-#edit{
-    cursor: pointer;
-    position: absolute;
-    top: 0;
-    left: 0;
-    z-index: 1;
-    width: 80px;
-    height: 80px;
-    background: rgba(0, 0, 0, .5);
-    border: 1px solid #4ecc72;
-    clip-path: polygon(
-        0 10%,
-        10% 0,
-        90% 0,
-        100% 10%,
-        100% 90%,
-        90% 100%,
-        10% 100%,
-        0% 90%,
-        0% 10%
-    )
-}

--- a/public/index.htm
+++ b/public/index.htm
@@ -9,7 +9,6 @@
 <link rel="stylesheet" href="./css/index.css">
 </head>
 <body>
-    <div id="edit"></div>
     <div id="configure"> CONFIGURE </div>
     <div id="keyControl"> ENABLE KEYS </div>
     <div id="trash"></div>
@@ -23,9 +22,6 @@
             <div class="menuButton" id="updateSoftware">update robot software</div>
             <div class="menuButton" id="saveConfig">save config</div>
             <div class="menuButton" id="addWidget">add widget</div>
-            <br/>
-            <input id="socketUri" type="text" />
-            <div class="menuButton" id="setSocket">set socket</div>
         </form>
     </div>
     <div id="newWidget" title="Configure a New Widget">

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -165,7 +165,6 @@ $(function () {
     autoOpen: false,
     open: function (event, ui) {
       $('#newWidget').dialog('close')
-      $('#socketUri').val(objSocket.io.uri)
     }
   })
   $('#configure').on('click', function () {
@@ -173,10 +172,6 @@ $(function () {
   })
   $('#keyDrive').on('click', (eventData) => {
     keyDriveControl(eventData)
-  })
-  $('#setSocket').on('click', function () {
-    objSocket.io.uri = $('#socketUri').val()
-    objSocket.connect()
   })
   $('#addWidget').on('click', function () {
     $('#newWidget').dialog('open')
@@ -213,16 +208,6 @@ $(function () {
     }
   })
 
-  // edit corner can add a new widget by clicking or tapping, or edit a widget that is dropped into it
-  $('#edit').on('click', function () {
-    $('#newWidget').dialog('open')
-  }).droppable({
-    accept: '.widget',
-    drop: function (event, ui) {
-      console.log('dropped', ui.draggable.data('widget-id'))
-      ui.draggable.remove()
-    }
-  })
   $('#newWidget #newWidgetType').selectmenu({
     change: function (event, ui) {
       const widgetType = ui.item.value

--- a/public/js/rq_params.js
+++ b/public/js/rq_params.js
@@ -12,7 +12,7 @@
 
 const RQ_PARAMS = {}
 
-RQ_PARAMS.VERSION = '14rc2'
+RQ_PARAMS.VERSION = '14rc3'
 
 RQ_PARAMS.CONFIG_FORMAT_VERSION = '3'
 RQ_PARAMS.CONFIG_FILE = 'persist/configuration.json'

--- a/src/params.js
+++ b/src/params.js
@@ -8,7 +8,7 @@
 const path = require('path')
 
 const RQ_PARAMS = {}
-RQ_PARAMS.VERSION = '14rc2'
+RQ_PARAMS.VERSION = '14rc3'
 
 RQ_PARAMS.CONFIG_FORMAT_VERSION = '3'
 RQ_PARAMS.SERVER_STATIC_DIR = path.join(


### PR DESCRIPTION
The blank square in the top-left corner of the UI was intended as a way to add a new widget and to edit the configuration of an existing widget. It was removed because it didn't work correctly for either purpose.
New widgets can be added using the Configuration Settings. There is currently no way to edit and existing widget, beyond creating a new instance and deleting the old.

The set socket option was removed from the Configuration Settings because it was no longer needed and would likely confuse end users.

Issue #52