### PR TITLE
Reduced the latency between joystick/key events and motor motion

### DIFF
--- a/public/config/configuration.json
+++ b/public/config/configuration.json
@@ -298,7 +298,7 @@
         ],
         "topicType": "geometry_msgs/msg/TwistStamped",
         "topicDirection": "publish",
-        "topicPeriodS": 1
+        "topicPeriodS": 3
       },
       "keys": {
         "37": {
@@ -372,7 +372,7 @@
           "name"
         ],
         "topicType": "rq_msgs/msg/ServoAngles",
-        "topicPeriodS": 1
+        "topicPeriodS": 3
       },
       "keys": {
         "81": {
@@ -416,9 +416,9 @@
           "name"
         ],
         "topicType": "rq_msgs/msg/ServoAngles",
-        "topicPeriodS": 1
+        "topicPeriodS": 3
       }
     }
   ],
-  "version": "4"
+  "version": "5"
 }

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -69,8 +69,6 @@ const updateWidgetPosition = function (oldPosition, newPosition) {
  * Instantiate a widget defined in the configuration file or
  * via the configuration menu.
  *
- * The class RQ_PARAMS.WIDGET_CLASS is used exclusively by all RQ UI widgets, as
- * a means to retrieve the collection.
  * The widget's configuration label attribute is used to find a specific
  * widget.
  *
@@ -89,6 +87,7 @@ const createWidget = function (objWidget, objSocket) {
   // TODO: rq widget namespace.
   const widgetTypeUpper = objWidget.type.toUpperCase()
 
+  // TODO: Figure out how to replace the string 'widget' with a constant
   const widgetContainer = jQuery(
     `<div class="widget ${widgetTypeUpper}" id="${objWidget.label}"></div>`
   )

--- a/public/js/key_control.js
+++ b/public/js/key_control.js
@@ -11,6 +11,10 @@ class KeyControl { // eslint-disable-line no-unused-vars
    * Setup to manage key events. Requires an HTML element in the page with
    * the HTML ID set to the CSS string in keyButtonId.
    *
+   * If key events will be the primary way to command the robot, set the relevant
+   * topicPeriodS attribute to a value about twice the period of the key event repeat
+   * frequency.
+   *
    * @param {string} keyButtonId - the CSS string identifying the UI KEY button
    */
   constructor (keyButtonId) {

--- a/public/js/rq_params.js
+++ b/public/js/rq_params.js
@@ -12,9 +12,9 @@
 
 const RQ_PARAMS = {}
 
-RQ_PARAMS.VERSION = '14rc3'
+RQ_PARAMS.VERSION = '15'
 
-RQ_PARAMS.CONFIG_FORMAT_VERSION = '4'
+RQ_PARAMS.CONFIG_FORMAT_VERSION = '5'
 RQ_PARAMS.CONFIG_FILE = 'persist/configuration.json'
 RQ_PARAMS.MESSAGE_DURATION_S = 15
 
@@ -24,8 +24,9 @@ RQ_PARAMS.DISCONNECTED_IMAGE = 'img/background.jpg'
 // multiple topic attributes are delimited with this character
 RQ_PARAMS.ATTR_DELIMIT = ';'
 
+// TODO: Implement use of this in public/js/index.js
 RQ_PARAMS.WIDGET_NAMESPACE = 'rq'
-RQ_PARAMS.WIDGET_CLASS = 'widget'
+
 RQ_PARAMS.PING_TIMEOUT_MS = 1500
 RQ_PARAMS.PING_INTERVAL_MS = 1500
 RQ_PARAMS.SOCKET_TIMEOUT_MS = 1000

--- a/src/params.js
+++ b/src/params.js
@@ -8,9 +8,9 @@
 const path = require('path')
 
 const RQ_PARAMS = {}
-RQ_PARAMS.VERSION = '14rc3'
+RQ_PARAMS.VERSION = '15'
 
-RQ_PARAMS.CONFIG_FORMAT_VERSION = '4'
+RQ_PARAMS.CONFIG_FORMAT_VERSION = '5'
 RQ_PARAMS.SERVER_STATIC_DIR = path.join(
   __dirname, '../public')
 RQ_PARAMS.DEFAULT_CONFIG_FILE = path.join(


### PR DESCRIPTION
Optimized some code and fixed a defect in some code, in order to reduce the latency between a joystick command or key press and control of the motors.

Tested by running the containers on the RaspPi, enabling the keys, and then alternately wiggling the joystick and pressing various keys.

Issue #86