### PR TITLE
Updates for handling published topics without hard-coding the message

### DIFF
--- a/public/config/configuration.json
+++ b/public/config/configuration.json
@@ -418,6 +418,29 @@
         "topicType": "rq_msgs/msg/ServoAngles",
         "topicPeriodS": 3
       }
+    },
+    {
+      "position": {
+        "my": "left top",
+        "at": "left+354 top+242.5833282470703"
+      },
+      "format": {
+        "min": 0,
+        "max": 100,
+        "step": 5,
+        "default": 100,
+        "orientation": "horizontal",
+        "animate": "true"
+      },
+      "data": {
+        "topicDirection": "publish",
+        "topic": "motor_speed",
+        "topicType": "rq_msgs/msg/MotorSpeed",
+        "topicAttribute": "max_speed"
+      },
+      "type": "slider",
+      "label": "MotorSpeed",
+      "id": 21
     }
   ],
   "version": "5"

--- a/public/js/wSlider.js
+++ b/public/js/wSlider.js
@@ -1,6 +1,7 @@
 'use strict'
 /* global jQuery, RQ_PARAMS */
 
+// TODO: disable arrow key control of the slider when it has focus
 jQuery.widget(RQ_PARAMS.WIDGET_NAMESPACE + '.SLIDER', {
   options: {
     socket: null,
@@ -67,8 +68,16 @@ jQuery.widget(RQ_PARAMS.WIDGET_NAMESPACE + '.SLIDER', {
     if (this.options.socket) {
       this.element.find('.sliderCurrent').text(ui.value)
       const objPayload = {}
-      objPayload[this.options.data.topicAttribute[0]] = ui.value
-      objPayload[this.options.data.topicAttribute[1]] = this.options.label
+      /*
+       * A slider may use one or two topicAttributes. When only one, it's
+       * a string. When two, it's an Array of two strings.
+       */
+      if (this.options.data.topicAttribute instanceof Array) {
+        objPayload[this.options.data.topicAttribute[0]] = ui.value
+        objPayload[this.options.data.topicAttribute[1]] = this.options.label
+      } else {
+        objPayload[this.options.data.topicAttribute] = ui.value
+      }
       this.options.socket.emit(
         this.options.data.topic,
         JSON.stringify(objPayload)

--- a/scripts/dstart.sh
+++ b/scripts/dstart.sh
@@ -13,6 +13,7 @@ printf "Starting %s on %s\n" "$IMAGE" $DOCKER_HOST
 docker run -it --rm \
         --network host \
         --ipc host \
+        --env "ROS_DOMAIN_ID=72" \
         -v /dev/shm:/dev/shm \
         -v /tmp/update_fifo:/tmp/update_fifo \
         -v /opt/persist:${PERSIST_DIR} \

--- a/src/robot_comms.js
+++ b/src/robot_comms.js
@@ -250,8 +250,17 @@ class RobotComms {
       }
 
       default: {
-        this.logger.warn(`messages for topic ${topicName} not yet implemented`)
-        return null
+        const publishMessage = {
+          header: {
+            stamp: getRosTimestamp(),
+            frame_id: ''
+          }
+        }
+        for (const attribute in message) {
+          set(publishMessage, attribute, message[attribute])
+        }
+
+        return publishMessage
       }
     }
   }


### PR DESCRIPTION
Updated wSlider.js to handle both one and two attribute messages. Updated dstart.sh to set the default ROS_DOMAIN_ID to 72 instead of 0. Updated RobotComms to handle some messages without hard-coding them.

Tested by adding a slider widget for the /motor_speed topic and MotorSpeed message, then commanding the drive motors via both joystick and keys. See the rq_core PR for more details.

Requires [rq_core PR ]() and [rq_msgs PR ]().