### PR TITLE
Configure, add, and remove widget keys

### DIFF
--- a/public/index.htm
+++ b/public/index.htm
@@ -25,10 +25,17 @@
             <div class="menuButton" id="configKeys">config keys</div>
         </form>
     </div>
-    <div id="configKeysDialog" title="Configure widget keys">
+    <div id="configKeysDialog" title="Configure keys for widgets">
+      <!-- configKeysDefined gets a comma-separated list of keycodes -->
       <div id="configKeysDefined"></div>
       <br>
-      <div id="configKeysWidgetTable" title="Widgets">
+      <!-- configKeysWidgetTables gets a table with all the widgets -->
+      <div id="configKeysWidgetTable" title="Widgets list">
+      </div>
+    </div>
+    <div id="widgetKeysDialog" title="Configure widget keys">
+      <!-- widgetKeysForm gets a table of the keys for one widget -->
+      <div id="widgetKeysForm" title="Widget keys">
       </div>
     </div>
     <div id="newWidget" title="Configure a New Widget">

--- a/public/index.htm
+++ b/public/index.htm
@@ -27,12 +27,8 @@
     </div>
     <div id="configKeysDialog" title="Configure widget keys">
         <form id="configKeysForm">
-            <label>action:</label>
-            <select id="configKeysAction" name="action" data-section="root">
-                <option value="change">Change</option>
-                <option value="add">Add</option>
-                <option value="delete">Delete</option>
-            </select>
+            <div id="configKeysDefined"></div>
+            <br>
         </form>
     </div>
     <div id="newWidget" title="Configure a New Widget">

--- a/public/index.htm
+++ b/public/index.htm
@@ -38,6 +38,10 @@
       <br>
       <!-- widgetKeysForm gets a table of the keys for one widget -->
       <div id="widgetKeysForm" title="Widget keys">
+        <table>
+          <tbody id="widgetKeysTable">
+          </tbody>
+        </table>
       </div>
     </div>
     <div id="newWidget" title="Configure a New Widget">

--- a/public/index.htm
+++ b/public/index.htm
@@ -44,6 +44,13 @@
         </table>
       </div>
     </div>
+    <div id="keysHelpDialog" title="Widget key assignment help">
+      <div id="keysHelpWidgetType"></div>
+      <br>
+      <!--  keysHelpText gets a block of help text -->
+      <div id="keysHelpText" title="Help">
+      </div>
+    </div>
     <div id="newWidget" title="Configure a New Widget">
         <!-- TODO: A better id would be configureNewWidget -->
         <form id="newWidgetForm">
@@ -141,6 +148,7 @@
 <script src="./js/wIndicator.js"></script>
 <script src="./js/joy.min.js"></script>
 <script src="./js/wJoystick.js"></script>
+<script src="./js/key_help.js"></script>
 <script src="./js/key_control.js"></script>
 <script src="./js/index.js"></script>
 </html>

--- a/public/index.htm
+++ b/public/index.htm
@@ -9,8 +9,8 @@
 <link rel="stylesheet" href="./css/index.css">
 </head>
 <body>
-    <div id="configure"> CONFIGURE </div>
-    <div id="keyControl"> ENABLE KEYS </div>
+    <div id="configure">CONFIGURE</div>
+    <div id="keyControl">ENABLE KEYS</div>
     <div id="trash"></div>
     <div id="widgets"></div>
     <img id='mainImage'
@@ -22,6 +22,17 @@
             <div class="menuButton" id="updateSoftware">update robot software</div>
             <div class="menuButton" id="saveConfig">save config</div>
             <div class="menuButton" id="addWidget">add widget</div>
+            <div class="menuButton" id="configKeys">config keys</div>
+        </form>
+    </div>
+    <div id="configKeysDialog" title="Configure widget keys">
+        <form id="configKeysForm">
+            <label>action:</label>
+            <select id="configKeysAction" name="action" data-section="root">
+                <option value="change">Change</option>
+                <option value="add">Add</option>
+                <option value="delete">Delete</option>
+            </select>
         </form>
     </div>
     <div id="newWidget" title="Configure a New Widget">

--- a/public/index.htm
+++ b/public/index.htm
@@ -34,6 +34,8 @@
       </div>
     </div>
     <div id="widgetKeysDialog" title="Configure widget keys">
+      <div id="widgetKeysLabel"></div>
+      <br>
       <!-- widgetKeysForm gets a table of the keys for one widget -->
       <div id="widgetKeysForm" title="Widget keys">
       </div>

--- a/public/index.htm
+++ b/public/index.htm
@@ -26,10 +26,10 @@
         </form>
     </div>
     <div id="configKeysDialog" title="Configure widget keys">
-        <form id="configKeysForm">
-            <div id="configKeysDefined"></div>
-            <br>
-        </form>
+      <div id="configKeysDefined"></div>
+      <br>
+      <div id="configKeysWidgetTable" title="Widgets">
+      </div>
     </div>
     <div id="newWidget" title="Configure a New Widget">
         <!-- TODO: A better id would be configureNewWidget -->

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -272,8 +272,6 @@ jQuery(function () {
     keyControl.getKeyedWidgets()
 
     jQuery('#configKeysDialog').dialog('open')
-    jQuery('#configKeysDefined').text('Defined keys: ' + keyControl.getKeysSet())
-    jQuery('#configKeysWidgetTable').html(keyControl.showWidgets())
   }
 
   jQuery('#configKeysDialog').dialog({
@@ -286,6 +284,23 @@ jQuery(function () {
     },
     open: function (event, ui) {
       jQuery('#menuDialog').dialog('close')
+      jQuery('#configKeysDefined').text('Defined keys: ' + keyControl.getKeysSet())
+      jQuery('#configKeysWidgetTable').html(keyControl.showWidgets())
+    }
+  })
+
+  jQuery('#widgetKeysDialog').dialog({
+    width: 500,
+    autoOpen: false,
+    buttons: {
+      Cancel: function () {
+        jQuery(this).dialog('close')
+        jQuery('#configKeysDialog').dialog('open')
+      }
+    },
+    open: function (event, ui) {
+      jQuery('#configKeysDialog').dialog('close')
+      jQuery('#widgetKeysForm').html(keyControl.showKeycodes())
     }
   })
 

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -2,6 +2,10 @@
 
 /* global jQuery io RQ_PARAMS KeyControl */
 
+/**
+ * The main control for the RoboQuest front-end UI.
+ */
+
 console.info(`rq_ui version ${RQ_PARAMS.VERSION} starting`)
 console.info(`rq_ui config format version ${RQ_PARAMS.CONFIG_FORMAT_VERSION}`)
 
@@ -311,7 +315,7 @@ jQuery(function () {
         jQuery('#keysHelpDialog').dialog('open')
       },
       AddKey: keyControl.addKeyRow.bind(keyControl),
-      Apply: keyControl.applyKeycodeConfig,
+      Apply: keyControl.applyKeycodeConfig.bind(keyControl),
       Cancel: function () {
         jQuery(this).dialog('close')
         jQuery('#keysHelpDialog').dialog('close')

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -269,10 +269,11 @@ jQuery(function () {
    * assigned to widgets.
    */
   const configKeys = function () {
-    const allWidgets = keyControl.getKeyedWidgets()
+    keyControl.getKeyedWidgets()
 
     jQuery('#configKeysDialog').dialog('open')
     jQuery('#configKeysDefined').text('Defined keys: ' + keyControl.getKeysSet())
+    jQuery('#configKeysWidgetTable').html(keyControl.showWidgets())
   }
 
   jQuery('#configKeysDialog').dialog({

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -239,6 +239,31 @@ jQuery(function () {
     positionWidgets()
   }
 
+  /**
+   * Save the configuration object. Called by clicking the "save config" button
+   * and by KeyControl.
+   */
+  const saveConfig = function () {
+    const objSaveConfig = {
+      widgets: []
+    }
+    jQuery('.widget').each((i, element) => {
+      objSaveConfig.widgets.push(jQuery(element).data('widget'))
+    })
+    jQuery.ajax({
+      type: 'POST',
+      url: '/config',
+      contentType: 'application/json',
+      data: JSON.stringify(objSaveConfig),
+      success: function (objResponse) {
+        console.debug('Save Config Response', objResponse)
+      },
+      error: function (objRequest, strStatus, strError) {
+        console.error('Error saving config:', strError)
+      }
+    })
+  }
+
   jQuery('#newWidget').dialog({
     width: 500,
     autoOpen: false,
@@ -266,26 +291,10 @@ jQuery(function () {
   jQuery('#addWidget').on('click', function () {
     jQuery('#newWidget').dialog('open')
   })
-  jQuery('#saveConfig').on('click', function () {
-    const objSaveConfig = {
-      widgets: []
-    }
-    jQuery('.widget').each((i, element) => {
-      objSaveConfig.widgets.push(jQuery(element).data('widget'))
-    })
-    jQuery.ajax({
-      type: 'POST',
-      url: '/config',
-      contentType: 'application/json',
-      data: JSON.stringify(objSaveConfig),
-      success: function (objResponse) {
-        console.debug('Save Config Response', objResponse)
-      },
-      error: function (objRequest, strStatus, strError) {
-        console.error('Error saving config:', strError)
-      }
-    })
+  jQuery('#configKeys').on('click', function () {
+    console.debug('config keys clicked')
   })
+  jQuery('#saveConfig').on('click', saveConfig)
 
   jQuery('#updateSoftware').on('click', function () {
     if (objSocket.connected) {

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -292,6 +292,7 @@ jQuery(function () {
     }
   })
 
+  // TODO: Reload the (re)assigned keys on the close event
   jQuery('#configKeysDialog').dialog({
     width: 500,
     autoOpen: false,

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -300,6 +300,7 @@ jQuery(function () {
     },
     open: function (event, ui) {
       jQuery('#configKeysDialog').dialog('close')
+      jQuery('#widgetKeysLabel').text(keyControl.configureWidgetLabel())
       jQuery('#widgetKeysForm').html(keyControl.showKeycodes())
     }
   })

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -310,7 +310,7 @@ jQuery(function () {
       Help: function () {
         jQuery('#keysHelpDialog').dialog('open')
       },
-      AddKey: keyControl.addKeyRow,
+      AddKey: keyControl.addKeyRow.bind(keyControl),
       Apply: keyControl.applyKeycodeConfig,
       Cancel: function () {
         jQuery(this).dialog('close')

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -264,6 +264,30 @@ jQuery(function () {
     })
   }
 
+  /**
+   * Execute the process for re-configuring the collection of keys
+   * assigned to widgets.
+   */
+  const configKeys = function () {
+    const allWidgets = keyControl.getKeyedWidgets()
+
+    jQuery('#configKeysDialog').dialog('open')
+    jQuery('#configKeysDefined').text('Defined keys: ' + keyControl.getKeysSet())
+  }
+
+  jQuery('#configKeysDialog').dialog({
+    width: 500,
+    autoOpen: false,
+    buttons: {
+      Cancel: function () {
+        jQuery(this).dialog('close')
+      }
+    },
+    open: function (event, ui) {
+      jQuery('#menuDialog').dialog('close')
+    }
+  })
+
   jQuery('#newWidget').dialog({
     width: 500,
     autoOpen: false,
@@ -291,9 +315,7 @@ jQuery(function () {
   jQuery('#addWidget').on('click', function () {
     jQuery('#newWidget').dialog('open')
   })
-  jQuery('#configKeys').on('click', function () {
-    console.debug('config keys clicked')
-  })
+  jQuery('#configKeys').on('click', configKeys)
   jQuery('#saveConfig').on('click', saveConfig)
 
   jQuery('#updateSoftware').on('click', function () {

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -297,7 +297,7 @@ jQuery(function () {
     width: 500,
     autoOpen: false,
     buttons: {
-      Cancel: function () {
+      Done: function () {
         jQuery(this).dialog('close')
       }
     },
@@ -317,7 +317,7 @@ jQuery(function () {
       },
       AddKey: keyControl.addKeyRow.bind(keyControl),
       Apply: keyControl.applyKeycodeConfig.bind(keyControl),
-      Cancel: function () {
+      Done: function () {
         jQuery(this).dialog('close')
         jQuery('#keysHelpDialog').dialog('close')
         jQuery('#configKeysDialog').dialog('open')
@@ -335,7 +335,7 @@ jQuery(function () {
     autoOpen: false,
     buttons: {
       Create: addWidget,
-      Cancel: function () {
+      Done: function () {
         jQuery(this).dialog('close')
       }
     },

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -274,6 +274,20 @@ jQuery(function () {
     jQuery('#configKeysDialog').dialog('open')
   }
 
+  jQuery('#keysHelpDialog').dialog({
+    width: 300,
+    autoOpen: false,
+    buttons: {
+      Close: function () {
+        jQuery(this).dialog('close')
+      }
+    },
+    open: function (event, ui) {
+      jQuery('#keysHelpWidgetType').text(keyControl.getWidgetType())
+      jQuery('#keysHelpText').text(keyControl.getHelpText())
+    }
+  })
+
   jQuery('#configKeysDialog').dialog({
     width: 500,
     autoOpen: false,
@@ -293,8 +307,14 @@ jQuery(function () {
     width: 500,
     autoOpen: false,
     buttons: {
+      Help: function () {
+        jQuery('#keysHelpDialog').dialog('open')
+      },
+      AddKey: keyControl.addKeyRow,
+      Apply: keyControl.applyKeycodeConfig,
       Cancel: function () {
         jQuery(this).dialog('close')
+        jQuery('#keysHelpDialog').dialog('close')
         jQuery('#configKeysDialog').dialog('open')
       }
     },

--- a/public/js/key_control.js
+++ b/public/js/key_control.js
@@ -42,11 +42,9 @@ class KeyControl { // eslint-disable-line no-unused-vars
    * @param {string} keycodeId - the HTML ID of the keycoded button
    */
   changeAssignedKeycode (keycodeId) {
-    console.debug(`changeAssignedKeycode called on ${keycodeId}`)
     jQuery(window).on('keydown', (eventData) => {
       jQuery(window).off('keydown')
       const keycodeButton = jQuery(`#${keycodeId}`)
-      console.debug(`changeAssignedKeycode: h ${keycodeButton.html()} t ${keycodeButton.text()}`)
       jQuery(`#${keycodeId}`).html(`${eventData.which}`)
     })
   }
@@ -231,9 +229,9 @@ class KeyControl { // eslint-disable-line no-unused-vars
       )
 
     let keycodesRow = ''
+    this._rowIndex = 0
     if (this._configureWidgetObj.keys) {
       this._widgetId = this._configureWidgetObj.id
-      this._rowIndex = 0
 
       for (const keyCode of Object.keys(this._configureWidgetObj.keys)) {
         const keyConfig = this._configureWidgetObj.keys[keyCode]
@@ -266,7 +264,7 @@ class KeyControl { // eslint-disable-line no-unused-vars
     let keycodesRow = ''
 
     keycodesRow = '<tr>'
-    keycodesRow += `<td><button id="keycode_${this._rowIndex}" onclick="keyControl.changeAssignedKeycode('${this._rowIndex}:keycode')">0</button></td>`
+    keycodesRow += `<td><button id="keycode_${this._rowIndex}" onclick="keyControl.changeAssignedKeycode('keycode_${this._rowIndex}')">0</button></td>`
     keycodesRow += `<td><input id="name_${this._rowIndex}" type="text" size="10"></td>`
     keycodesRow += `<td><input id="downValues_${this._rowIndex}" type="text" size=20></td>`
     keycodesRow += `<td><input id="upValues_${this._rowIndex}" type="text" size=20></td>`

--- a/public/js/key_control.js
+++ b/public/js/key_control.js
@@ -44,7 +44,6 @@ class KeyControl { // eslint-disable-line no-unused-vars
   changeAssignedKeycode (keycodeId) {
     jQuery(window).on('keydown', (eventData) => {
       jQuery(window).off('keydown')
-      const keycodeButton = jQuery(`#${keycodeId}`)
       jQuery(`#${keycodeId}`).html(`${eventData.which}`)
     })
   }
@@ -208,17 +207,63 @@ class KeyControl { // eslint-disable-line no-unused-vars
   }
 
   /**
-   * Read the #widgetKeysTable input elements to extract the configuration
-   * of keycodes and use them to update this._configureWidgetObj.keys.
+   * Read the #widgetKeysTable rows input elements to extract the
+   * configuration of keycodes and use them to update this._configureWidgetObj.keys.
+   * Each element of the table is expected to be identified with a unique HTML element
+   * ID in the format "${columnName}_${rowIndex}" where columnName is from
+   * ['keycode', 'name', 'downValues', 'upValues'].
+   *
+      "keys": {
+        "37": {
+          "name": "left",
+          "downValues": {
+            "x": 50,
+            "y": 0
+          },
+          "upValues": {
+            "x": 0,
+            "y": 0
+          }
+        },
+        "38": {
+          "name": "forward",
+          "downValues": {
+            "x": 0,
+            "y": 50
+          },
+          "upValues": {
+            "x": 0,
+            "y": 0
+          }
+        },
    */
   applyKeycodeConfig () {
-    console.debug('applyKeycodeConfig: Not implemented yet')
+    const newKeysConfig = {}
+    console.debug(`applyKeycodeConfig: ${this._rowIndex} rows in table`)
+
+    for (let rowIndex = 0; rowIndex < this._rowIndex; rowIndex++) {
+      const newKeycode = jQuery('#' + `keycode_${rowIndex}`).text()
+      if (newKeycode && newKeycode !== '0') {
+        newKeysConfig[newKeycode] = {}
+
+        newKeysConfig[newKeycode].name = jQuery('#' + `name_${rowIndex}`).val()
+        newKeysConfig[newKeycode].downValues = jQuery('#' + `downValues_${rowIndex}`).val()
+        newKeysConfig[newKeycode].upValues = jQuery('#' + `upValues_${rowIndex}`).val()
+
+        console.debug(`${newKeycode}: ${JSON.stringify(newKeysConfig[newKeycode])}`)
+      }
+    }
+    console.debug(`All: ${JSON.stringify(newKeysConfig)}`)
+    // this._configureWidgetObj.keys = {}
   }
 
   /**
    * Add a row to the HTML element ID widgetKeysTable for each assigned keycode.
    * KeyControl.configureWidget() must have been called before calling
    * showKeycodes(), so that this._configureWidgetObj is up to date.
+   *
+   * The column HTML element IDs are formed from the strings in
+   * KEY_COLUMN_NAMES.
    */
   showKeycodes () {
     jQuery('#widgetKeysTable').children('tr').remove()
@@ -259,6 +304,9 @@ class KeyControl { // eslint-disable-line no-unused-vars
   /**
    * Add an empty row to the table of widget keys, so a new key
    * assignment can be made. Can't be called before showKeycodes().
+   *
+   * The column HTML element IDs are formed from the strings in
+   * KEY_COLUMN_NAMES.
    */
   addKeyRow () {
     let keycodesRow = ''

--- a/public/js/key_control.js
+++ b/public/js/key_control.js
@@ -20,11 +20,55 @@ class KeyControl { // eslint-disable-line no-unused-vars
   constructor (keyButtonId) {
     this._keyButtonId = keyButtonId
     this._keyToWidget = {}
+    this._keyableWidgets = []
+    this._keysSet = []
     this._keyboardIsEnabled = false
 
     jQuery(this._keyButtonId).on('click', (eventData) => {
       this._handleKeysButton(eventData)
     })
+  }
+
+  /**
+   * getKeyedWidgets returns an Array of those widgets where the
+   * type is in [ Joystick, Button, Slider ] and keys are assigned.
+   *
+   * @returns {Array} - list of widgets with assigned keys
+   */
+  getKeyedWidgets () {
+    this._keyableWidgets = []
+    const keyControl = this
+    jQuery('.BUTTON, .JOYSTICK, .SLIDER').each(function (index) {
+      // TODO: Further check for defined keys
+      keyControl._keyableWidgets.push(this)
+    })
+
+    return this._keyableWidgets
+  }
+
+  /**
+   * Given a widget object as an input, extract the keys assigned to the widget
+   * and add them to this._keysSet.
+   *
+   * @param {object} widget - the widget configuration object
+   */
+  _extractAssignedKeys (widget) {
+    const widgetObj = jQuery(widget).data('widget')
+    if (Object.hasOwn(widgetObj, 'keys')) {
+      this._keysSet = this._keysSet.concat(Object.keys(widgetObj.keys))
+    }
+  }
+
+  /**
+   * Return the set of assigned keys as a string.
+   *
+   * @returns {string} - the set of assigned keys
+   */
+  getKeysSet () {
+    this._keysSet = []
+    this._keyableWidgets.forEach(this._extractAssignedKeys.bind(this))
+
+    return String(this._keysSet)
   }
 
   /**

--- a/public/js/key_control.js
+++ b/public/js/key_control.js
@@ -286,7 +286,8 @@ class KeyControl { // eslint-disable-line no-unused-vars
 
     for (let rowIndex = 0; rowIndex < this._rowIndex; rowIndex++) {
       const newKeycode = jQuery('#' + `keycode_${rowIndex}`).text()
-      if (newKeycode && newKeycode !== '0') {
+      const remove = jQuery('#' + `remove_${rowIndex}`).is(':checked')
+      if (newKeycode && newKeycode !== '0' && !remove) {
         newKeysConfig[newKeycode] = {}
 
         newKeysConfig[newKeycode].name = jQuery('#' + `name_${rowIndex}`).val()
@@ -327,7 +328,7 @@ class KeyControl { // eslint-disable-line no-unused-vars
 
     jQuery('#widgetKeysTable')
       .append(
-        '<tr><th>Keycode</th><th>Key Name</th><th>On Press</th><th>On Release</th></tr>'
+        '<tr><th>Keycode</th><th>Key Name</th><th>On Press</th><th>On Release</th><th>Remove</th></tr>'
       )
 
     let keycodesRow = ''
@@ -350,6 +351,7 @@ class KeyControl { // eslint-disable-line no-unused-vars
           upValuesStr = JSON.stringify(keyConfig.upValues).replace(/"/g, '').replace(/{/g, '').replace(/}/g, '')
         }
         keycodesRow += `<td><input id="upValues_${this._rowIndex}" type="text" size=20 value="${upValuesStr}"></td>`
+        keycodesRow += `<td><input id="remove_${this._rowIndex}" type="checkbox"></td>`
         keycodesRow += '</tr>'
 
         jQuery('#widgetKeysTable').append(keycodesRow)
@@ -373,6 +375,7 @@ class KeyControl { // eslint-disable-line no-unused-vars
     keycodesRow += `<td><input id="name_${this._rowIndex}" type="text" size="10"></td>`
     keycodesRow += `<td><input id="downValues_${this._rowIndex}" type="text" size=20></td>`
     keycodesRow += `<td><input id="upValues_${this._rowIndex}" type="text" size=20></td>`
+    keycodesRow += `<td><input id="remove_${this._rowIndex}" type="checkbox" size=20></td>`
     keycodesRow += '</tr>'
 
     jQuery('#widgetKeysTable').append(keycodesRow)

--- a/public/js/key_control.js
+++ b/public/js/key_control.js
@@ -58,6 +58,7 @@ class KeyControl { // eslint-disable-line no-unused-vars
    *
    * @param {object} objWidget - the object describing the widget configuration
    */
+  // TODO: Change the argument to expect the keys sub-object directly so keyConfig can use it
   addKeysForWidget (objWidget) {
     for (const key in objWidget.keys) {
       this._mapKeyToWidget(

--- a/public/js/key_control.js
+++ b/public/js/key_control.js
@@ -103,10 +103,22 @@ class KeyControl { // eslint-disable-line no-unused-vars
     this._widgetsTable += ('<tr>' +
       `<td>${widgetObj.label}</td>` +
       `<td>${widgetObj.type}</td>` +
-      '<td><button id="edit">Edit</button></td>' +
+      `<td><button onclick="keyControl.configureWidget(${widgetObj.id})">Edit</button></td>` +
       `<td>${hasKeys}</td>` +
       '</tr>'
     )
+  }
+
+  /**
+   * Record the ID of the widget having its key assignments configured and then
+   * open the widgetKeysDialog. This is how the widget ID is made available to
+   * this.showKeycodes.
+   *
+   * @param {number} widgetId - the unique ID of the widget having its keys configured
+   */
+  configureWidget (widgetId) {
+    this._configureWidgetId = widgetId
+    jQuery('#widgetKeysDialog').dialog('open')
   }
 
   /**
@@ -121,6 +133,16 @@ class KeyControl { // eslint-disable-line no-unused-vars
     this._widgetsTable += '</table>'
 
     return this._widgetsTable
+  }
+
+  /**
+   * Return an HTML form element with the keycodes.
+   *
+   * @returns {string} - HTML to define a form of keycode configurations
+   */
+  showKeycodes () {
+    // TODO: Implement
+    return `Widget ID: ${this._configureWidgetId}`
   }
 
   /**

--- a/public/js/key_control.js
+++ b/public/js/key_control.js
@@ -110,14 +110,21 @@ class KeyControl { // eslint-disable-line no-unused-vars
   }
 
   /**
-   * Record the ID of the widget having its key assignments configured and then
-   * open the widgetKeysDialog. This is how the widget ID is made available to
+   * Record the widget having its key assignments configured and then
+   * open the widgetKeysDialog. This is how the widget is made available to
    * this.showKeycodes.
    *
    * @param {number} widgetId - the unique ID of the widget having its keys configured
    */
   configureWidget (widgetId) {
-    this._configureWidgetId = widgetId
+    this._configureWidgetObj = null
+    const keyControl = this
+    this._keyableWidgets.forEach(function (widget) {
+      const widgetObj = jQuery(widget).data('widget')
+      if (widgetObj.id === widgetId) {
+        keyControl._configureWidgetObj = widgetObj
+      }
+    })
     jQuery('#widgetKeysDialog').dialog('open')
   }
 
@@ -136,13 +143,45 @@ class KeyControl { // eslint-disable-line no-unused-vars
   }
 
   /**
+   * Return the label for the widget being configured.
+   *
+   * @returns {string} - the widget's label
+   */
+  configureWidgetLabel () {
+    return this._configureWidgetObj.label
+  }
+
+  /**
    * Return an HTML form element with the keycodes.
    *
    * @returns {string} - HTML to define a form of keycode configurations
    */
   showKeycodes () {
-    // TODO: Implement
-    return `Widget ID: ${this._configureWidgetId}`
+    let keycodesTable = '<table><tr><th>Keycode</th><th>Name</th><th>Press</th><th>Release</th></tr>'
+    if (!this._configureWidgetObj.keys) {
+      return 'None assigned'
+    }
+
+    for (const keyCode of Object.keys(this._configureWidgetObj.keys)) {
+      const keyConfig = this._configureWidgetObj.keys[keyCode]
+      keycodesTable += '<tr>'
+      keycodesTable += `<td>${keyCode}</td>`
+      keycodesTable += `<td>${keyConfig.name}</td>`
+      if (keyConfig.downValues) {
+        keycodesTable += `<td>${JSON.stringify(keyConfig.downValues)}</td>`
+      } else {
+        keycodesTable += '<td></td>'
+      }
+      if (keyConfig.upValues) {
+        keycodesTable += `<td>${JSON.stringify(keyConfig.upValues)}</td>`
+      } else {
+        keycodesTable += '<td></td>'
+      }
+      keycodesTable += '</tr>'
+    }
+    keycodesTable += '</table>'
+
+    return keycodesTable
   }
 
   /**

--- a/public/js/key_control.js
+++ b/public/js/key_control.js
@@ -30,20 +30,37 @@ class KeyControl { // eslint-disable-line no-unused-vars
   }
 
   /**
-   * getKeyedWidgets returns an Array of those widgets where the
-   * type is in [ Joystick, Button, Slider ] and keys are assigned.
+   * Sort the collection of widgets by their labels.
    *
-   * @returns {Array} - list of widgets with assigned keys
+   * @param {object} first - the first widget
+   * @param {object} second - the second widget
+   */
+  _sortKeyableWidgets (first, second) {
+    const firstWidgetLabel = jQuery(first).data('widget').label
+    const secondWidgetLabel = jQuery(second).data('widget').label
+
+    if (firstWidgetLabel === secondWidgetLabel) {
+      return 0
+    } else if (firstWidgetLabel < secondWidgetLabel) {
+      return -1
+    } else {
+      return 1
+    }
+  }
+
+  /**
+   * getKeyedWidgets creates an Array of those widgets where the
+   * type is in [ Joystick, Button, Slider ]. It doesn't care if
+   * keys are assigned.
+   * This method must be called before getKeysSet().
    */
   getKeyedWidgets () {
     this._keyableWidgets = []
     const keyControl = this
     jQuery('.BUTTON, .JOYSTICK, .SLIDER').each(function (index) {
-      // TODO: Further check for defined keys
       keyControl._keyableWidgets.push(this)
     })
-
-    return this._keyableWidgets
+    keyControl._keyableWidgets.sort(this._sortKeyableWidgets)
   }
 
   /**
@@ -60,7 +77,8 @@ class KeyControl { // eslint-disable-line no-unused-vars
   }
 
   /**
-   * Return the set of assigned keys as a string.
+   * Return the set of assigned keys as a string. getKeyedWidgets()
+   * must have been called prior to calling this method.
    *
    * @returns {string} - the set of assigned keys
    */
@@ -68,7 +86,41 @@ class KeyControl { // eslint-disable-line no-unused-vars
     this._keysSet = []
     this._keyableWidgets.forEach(this._extractAssignedKeys.bind(this))
 
-    return String(this._keysSet)
+    return String(this._keysSet.sort())
+  }
+
+  /**
+   * Add an HTML table row to this._widgetsTable for the widget.
+   *
+   * @param {object} widget - the object defining the widget
+   */
+  _addWidgetRow (widget) {
+    const widgetObj = jQuery(widget).data('widget')
+    let hasKeys = 'None'
+    if (Object.hasOwn(widgetObj, 'keys')) {
+      hasKeys = 'Remove'
+    }
+    this._widgetsTable += ('<tr>' +
+      `<td>${widgetObj.label}</td>` +
+      `<td>${widgetObj.type}</td>` +
+      '<td><button id="edit">Edit</button></td>' +
+      `<td>${hasKeys}</td>` +
+      '</tr>'
+    )
+  }
+
+  /**
+   * Return an HTML table with each key-able widget on a separate row. All
+   * widgets are included, whether they have assigned keys or not.
+   *
+   * @returns {string} - HTML to define a table of widgets
+   */
+  showWidgets () {
+    this._widgetsTable = '<table><tr><th>Label</th><th>Type</th><th>Edit</th><th>Remove all</th></tr>'
+    this._keyableWidgets.forEach(this._addWidgetRow.bind(this))
+    this._widgetsTable += '</table>'
+
+    return this._widgetsTable
   }
 
   /**

--- a/public/js/key_help.js
+++ b/public/js/key_help.js
@@ -6,10 +6,12 @@
 
 const RQKeysHelp = {}
 
-RQKeysHelp.version = 1
+RQKeysHelp.version = 2
 
-RQKeysHelp.joystick = 'The joystick widget produces two number values, x and y. y is the position of the joystick forward and backward. x is the position side to side. The range for both x and y is [-100, 100]. When assigning a key to the joystick, specify the x and y values like "x: 50, y:0" where 50 and 0 can be any value in [-100, 100].'
+RQKeysHelp.keycodes = 'To change or set a keycode, click on the button in the Keycode column and then press and release the keyboard key.'
 
-RQKeysHelp.button = 'The button widget only produces a click event - it doesn\'t produce any value itself. The ON Press and On Release fields are ignored.'
+RQKeysHelp.joystick = 'The joystick widget produces two number values, x and y. y is the position of the joystick forward and backward. x is the position side to side. The range for both x and y is [-100, 100]. When assigning a key to the joystick, specify the x and y values like "x: 50, y:0" where 50 and 0 can be any value in [-100, 100].' + '   ' + RQKeysHelp.keycodes
 
-RQKeysHelp.slider = 'The slider widget produces a single value in the range defined when the widget was configured. When assigning a key to the slider, specify the On Press and/or On Release like "name:Whatever,value:4" where Whatever is a name of your choosing and 4 is any number in range.'
+RQKeysHelp.button = 'The button widget only produces a click event - it doesn\'t produce any value itself. The ON Press and On Release fields are ignored.' + '   ' + RQKeysHelp.keycodes
+
+RQKeysHelp.slider = 'The slider widget produces a single value in the range defined when the widget was configured. When assigning a key to the slider, specify the On Press and/or On Release like "name:Whatever,value:4" where Whatever is a name of your choosing and 4 is any number in range.' + '   ' + RQKeysHelp.keycodes

--- a/public/js/key_help.js
+++ b/public/js/key_help.js
@@ -1,0 +1,15 @@
+'use strict'
+
+/**
+ * The descriptive and help text about assigning keys for each type of widget.
+ */
+
+const RQKeysHelp = {}
+
+RQKeysHelp.version = 1
+
+RQKeysHelp.joystick = 'The joystick widget produces two number values, x and y. y is the position of the joystick forward and backward. x is the position side to side. The range for both x and y is [-100, 100]. When assigning a key to the joystick, specify the x and y values like "x: 50, y:0" where 50 and 0 can be any value in [-100, 100].'
+
+RQKeysHelp.button = 'The button widget only produces a click event - it doesn\'t produce any value itself. The ON Press and On Release fields are ignored.'
+
+RQKeysHelp.slider = 'The slider widget produces a single value in the range defined when the widget was configured. When assigning a key to the slider, specify the On Press and/or On Release like "name:Whatever,value:4" where Whatever is a name of your choosing and 4 is any number in range.'

--- a/public/js/key_help.js
+++ b/public/js/key_help.js
@@ -6,12 +6,14 @@
 
 const RQKeysHelp = {}
 
-RQKeysHelp.version = 2
+RQKeysHelp.version = 3
 
-RQKeysHelp.keycodes = 'To change or set a keycode, click on the button in the Keycode column and then press and release the keyboard key.'
+RQKeysHelp.keycodes = 'To change or set a keycode, click on the number in the Keycode column and then press and release the keyboard key. The number will change.'
 
-RQKeysHelp.joystick = 'The joystick widget produces two number values, x and y. y is the position of the joystick forward and backward. x is the position side to side. The range for both x and y is [-100, 100]. When assigning a key to the joystick, specify the x and y values like "x: 50, y:0" where 50 and 0 can be any value in [-100, 100].' + '   ' + RQKeysHelp.keycodes
+RQKeysHelp.done = 'When finished making changes, click the Apply button. To make the changes permanent, click "save config" in Configuration settings.'
 
-RQKeysHelp.button = 'The button widget only produces a click event - it doesn\'t produce any value itself. The ON Press and On Release fields are ignored.' + '   ' + RQKeysHelp.keycodes
+RQKeysHelp.joystick = 'The joystick widget produces two number values, x and y. y is the position of the joystick forward and backward. x is the position side to side. The range for both x and y is [-100, 100]. When assigning a key to the joystick, specify the x and y values like "x: 50, y:0" where 50 and 0 can be any value in [-100, 100].' + '   ' + RQKeysHelp.keycodes + ' ' + RQKeysHelp.done
 
-RQKeysHelp.slider = 'The slider widget produces a single value in the range defined when the widget was configured. When assigning a key to the slider, specify the On Press and/or On Release like "name:Whatever,value:4" where Whatever is a name of your choosing and 4 is any number in range.' + '   ' + RQKeysHelp.keycodes
+RQKeysHelp.button = 'The button widget only produces a click event - it doesn\'t produce any value itself. The ON Press and On Release fields are ignored.' + '   ' + RQKeysHelp.keycodes + ' ' + RQKeysHelp.done
+
+RQKeysHelp.slider = 'The slider widget produces a single value in the range defined when the widget was configured. When assigning a key to the slider, specify the On Press and/or On Release like "name:Whatever,value:4" where Whatever is a name of your choosing and 4 is any number in range.' + '   ' + RQKeysHelp.keycodes + ' ' + RQKeysHelp.done

--- a/public/js/rq_params.js
+++ b/public/js/rq_params.js
@@ -12,7 +12,7 @@
 
 const RQ_PARAMS = {}
 
-RQ_PARAMS.VERSION = '16'
+RQ_PARAMS.VERSION = '17'
 
 RQ_PARAMS.CONFIG_FORMAT_VERSION = '5'
 RQ_PARAMS.CONFIG_FILE = 'persist/configuration.json'


### PR DESCRIPTION
Added support for managing the keys assigned to widget types Joystick, Slider, and Button. Can now add keys to widgets without any, add more keys to widgets with some, delete keys from widgets, and change the values associated with both the key press and release.

To test click Configure, then "config keys". A list of all Joystick, Slider, and Button widgets will be displayed, including an indication of those which already have some keys assigned. To change the assignments for a widget, click the Edit button on its row.
On the "Configure widget keys" dialog will appear the keys, if any, which are already assigned to the widget. The keycode column has the number of the assigned keyboard key, which is NOT the character code. The Key Name column is used to describe the assigned key and, briefly, the action. On Press contains the value(s) produced when the key is pressed. On Release contains the value(s) produced when the key is released. The checkbox in the Remove column for each row is used to completely remove that key assignment from the widget. 
To assign an additional key, click the AddKey button.
When finished, click the Apply button and then the Done. For only those Keycode numbers which weren't changed, any change to their On Press and On Release values will be immediately affected.
To make the assignment and configuration changes permanent, click on "save config" in the Configuration Settings and then restart the robot.

See Issue #82 