### PR TITLE
Fixed the design bug related to empty downValues and upValues.

### DIFF
--- a/public/js/key_control.js
+++ b/public/js/key_control.js
@@ -306,6 +306,16 @@ class KeyControl { // eslint-disable-line no-unused-vars
         } else {
           delete newKeysConfig[newKeycode].upValues
         }
+
+        if (!Object.hasOwn(newKeysConfig[newKeycode], 'downValues') &&
+            !Object.hasOwn(newKeysConfig[newKeycode], 'upValues')) {
+          /*
+           * If neither downValues nor upValues are defined,
+           * an empty downValues object is required.
+           */
+          // TODO: Improve the key handler to not require an empty downValues
+          newKeysConfig[newKeycode].downValues = {}
+        }
       }
     }
     console.debug(


### PR DESCRIPTION
Fixed a bug exposed when a button widget has a new keycode assigned. Since buttons don't require either downValues or upValues, but the key handler logic requires at least an empty downValues, the updated code ensures a key assignment will always have at least an empty downValues.

Tested by both adding a key to a button without any and adding a key to a widget which already has keys assigned.

See Issue #93