### PR TITLE
Reload key configuration after config keys

### DIFF
--- a/public/js/index.js
+++ b/public/js/index.js
@@ -305,12 +305,13 @@ jQuery(function () {
     }
   })
 
-  // TODO: Reload the (re)assigned keys on the close event
   jQuery('#configKeysDialog').dialog({
     width: 500,
     autoOpen: false,
     buttons: {
       Done: function () {
+        keyControl.rebuildKeyMap()
+        saveConfig()
         jQuery(this).dialog('close')
       }
     },

--- a/public/js/key_control.js
+++ b/public/js/key_control.js
@@ -447,6 +447,31 @@ class KeyControl { // eslint-disable-line no-unused-vars
   }
 
   /**
+   * Completely rebuild the mapping of keys to widgets. Intended for use after
+   * the 'config keys' functionality.
+   */
+  rebuildKeyMap () {
+    this._keyToWidget = {}
+    this.getKeyedWidgets()
+
+    /*
+     * Iterate through the collection of keyed widgets and call addKeysForWidget
+     * for each one.
+     */
+    for (const widget of this._keyableWidgets) {
+      const widgetConfig = jQuery(widget).data('widget')
+      if (widgetConfig &&
+          Object.hasOwn(widgetConfig, 'keys') &&
+          Object.keys(widgetConfig.keys).length > 0) {
+        console.debug(`rebuildKeyMap: adding ${widgetConfig.label}`)
+        this.addKeysForWidget(widgetConfig)
+      } else {
+        console.debug(`rebuildKeyMap: skipping ${widgetConfig.label}`)
+      }
+    }
+  }
+
+  /**
    * Associate each of a collection of keys with a specific widget.
    *
    * @param {object} objWidget - the object describing the widget configuration

--- a/public/js/key_help.js
+++ b/public/js/key_help.js
@@ -8,7 +8,7 @@ const RQKeysHelp = {}
 
 RQKeysHelp.version = 3
 
-RQKeysHelp.keycodes = 'To change or set a keycode, click on the number in the Keycode column and then press and release the keyboard key. The number will change.'
+RQKeysHelp.keycodes = 'To change or set a key, click on the key name in the Key column and then press and release the keyboard key. If the new key is not assigned to another widget, the name will change.'
 
 RQKeysHelp.done = 'When finished making changes, click the Apply button. To make the changes permanent, click "save config" in Configuration settings.'
 


### PR DESCRIPTION
After using the "config keys" facility to change the assignment of keys to widgets, clicking the Done button at the bottom of the list of widgets will now both apply the updated key assignments and save the configuration file.

Tested by changing a key assignment and by deleting a key assignment.

Issue #95 