### PR TITLE
#72 Delete Widget and Namespace Solutions

### DIFF
--- a/public/css/index.css
+++ b/public/css/index.css
@@ -210,3 +210,7 @@ input, select{
         0% 10%
     )
 }
+
+.trash-drop-hover{
+    background-color: #3d0000 !important;
+}

--- a/public/css/index.css
+++ b/public/css/index.css
@@ -213,7 +213,7 @@ input, select{
 
 /* 
  * jQuery adds this class to the #trash element when a widget is hovering over the trash.
- * The important flag is used to overwrite the bacground attribute in the #trash style when this class is applied.
+ * The important flag is used to overwrite the background attribute in the #trash style when this class is applied.
  * Though the use of the important flag can lead to complications when multiple styles are applied to the same element,
  * it's perfectly fine for a simple trash bin with two states.
  */

--- a/public/css/index.css
+++ b/public/css/index.css
@@ -211,6 +211,12 @@ input, select{
     )
 }
 
+/* 
+ * jQuery adds this class to the #trash element when a widget is hovering over the trash.
+ * The important flag is used to overwrite the bacground attribute in the #trash style when this class is applied.
+ * Though the use of the important flag can lead to complications when multiple styles are applied to the same element,
+ * it's perfectly fine for a simple trash bin with two states.
+ */
 .trash-drop-hover{
-    background-color: #3d0000 !important;
+    background-color: #5e0000 !important; 
 }

--- a/public/js/key_control.js
+++ b/public/js/key_control.js
@@ -75,8 +75,8 @@ class KeyControl { // eslint-disable-line no-unused-vars
    * @param {object} second - the second widget
    */
   _sortKeyableWidgets (first, second) {
-    const firstWidgetLabel = jQuery(first).data('widget').label
-    const secondWidgetLabel = jQuery(second).data('widget').label
+    const firstWidgetLabel = jQuery(first).getWidgetConfiguration().label
+    const secondWidgetLabel = jQuery(second).getWidgetConfiguration().label
 
     if (firstWidgetLabel === secondWidgetLabel) {
       return 0
@@ -115,7 +115,7 @@ class KeyControl { // eslint-disable-line no-unused-vars
         continue
       }
 
-      const widgetData = jQuery(widget).data('widget')
+      const widgetData = jQuery(widget).getWidgetConfiguration()
       let widgetKeys = null
       if (!widgetData.keys) {
         continue
@@ -145,7 +145,7 @@ class KeyControl { // eslint-disable-line no-unused-vars
    * @param {object} widget - the object defining the widget
    */
   _addWidgetRow (widget) {
-    const widgetObj = jQuery(widget).data('widget')
+    const widgetObj = jQuery(widget).getWidgetConfiguration()
     let hasKeys = 'None'
     if (Object.hasOwn(widgetObj, 'keys')) {
       hasKeys = 'Yes'
@@ -203,7 +203,7 @@ class KeyControl { // eslint-disable-line no-unused-vars
     const keyControl = this
     // TODO: Replace the forEach with a simple iteration loop
     this._keyableWidgets.forEach(function (widget) {
-      const widgetObj = jQuery(widget).data('widget')
+      const widgetObj = jQuery(widget).getWidgetConfiguration()
       if (widgetObj.id === widgetId) {
         keyControl._configureWidgetObj = widgetObj
       }
@@ -459,7 +459,7 @@ class KeyControl { // eslint-disable-line no-unused-vars
      * for each one.
      */
     for (const widget of this._keyableWidgets) {
-      const widgetConfig = jQuery(widget).data('widget')
+      const widgetConfig = jQuery(widget).getWidgetConfiguration()
       if (widgetConfig &&
           Object.hasOwn(widgetConfig, 'keys') &&
           Object.keys(widgetConfig.keys).length > 0) {

--- a/public/js/rq_params.js
+++ b/public/js/rq_params.js
@@ -25,7 +25,7 @@ RQ_PARAMS.DISCONNECTED_IMAGE = 'img/background.jpg'
 RQ_PARAMS.ATTR_DELIMIT = ';'
 
 // TODO: Implement use of this in public/js/index.js
-RQ_PARAMS.WIDGET_NAMESPACE = 'rq'
+RQ_PARAMS.WIDGET_NAMESPACE = 'rq_widget'
 
 RQ_PARAMS.PING_TIMEOUT_MS = 1500
 RQ_PARAMS.PING_INTERVAL_MS = 1500

--- a/public/js/rq_params.js
+++ b/public/js/rq_params.js
@@ -25,7 +25,7 @@ RQ_PARAMS.DISCONNECTED_IMAGE = 'img/background.jpg'
 RQ_PARAMS.ATTR_DELIMIT = ';'
 
 // TODO: Implement use of this in public/js/index.js
-RQ_PARAMS.WIDGET_NAMESPACE = 'rq_widget'
+RQ_PARAMS.WIDGET_NAMESPACE = 'rq'
 
 RQ_PARAMS.PING_TIMEOUT_MS = 1500
 RQ_PARAMS.PING_INTERVAL_MS = 1500


### PR DESCRIPTION
**Changes**
To resolve issue #72

- Made the trash highlight when a widget is hovering over it, because sometimes it was hard to know if the widget was over the trash box.
- Resolved conflicts with the stop dragging event, to make sure we weren't attempting to operate on undefined objects. (solution, exit the stop dragging event if the widget is undefined).
- Changed `.data('widget)` to `.getWidgetData()` and extended the `jQuery` class to incorporate the QR WIDGET namespace.