### PR TITLE
Implemented ability to reload the servo config after a change

### DIFF
--- a/public/js/index.js
+++ b/public/js/index.js
@@ -363,8 +363,14 @@ jQuery(function () {
         jQuery('#configServoDialog').dialog('open')
       },
       Done: function () {
-        // TODO: Verify the format of the ServoConfig method names
+        // TODO: Verify the format and consistency of the ServoConfig method names
         servoConfig.save_servos()
+        console.debug('chooseServoDialog: emitting restart')
+        // TODO: Add a check if anything actually changed in the servo config
+        objSocket.emit(
+          'restart',
+          '{}'
+        )
         jQuery(this).dialog('close')
       }
     },

--- a/public/js/rq_params.js
+++ b/public/js/rq_params.js
@@ -12,7 +12,7 @@
 
 const RQ_PARAMS = {}
 
-RQ_PARAMS.VERSION = '19'
+RQ_PARAMS.VERSION = '20'
 
 RQ_PARAMS.CONFIG_FORMAT_VERSION = '6'
 RQ_PARAMS.CONFIG_FILE = 'persist/configuration.json'

--- a/src/params.js
+++ b/src/params.js
@@ -8,7 +8,7 @@
 const path = require('path')
 
 const RQ_PARAMS = {}
-RQ_PARAMS.VERSION = '19'
+RQ_PARAMS.VERSION = '20'
 
 RQ_PARAMS.CONFIG_FORMAT_VERSION = '6'
 RQ_PARAMS.SERVER_STATIC_DIR = path.join(

--- a/src/web_server.js
+++ b/src/web_server.js
@@ -15,7 +15,10 @@ class WebServer {
   constructor (clientName, configFile) {
     this.clientName = clientName
     this.configFile = configFile
-    this.incomingEvents = ['update']
+    /*
+     * update and restart aren't associated with any widget.
+     */
+    this.incomingEvents = ['update', 'restart']
     this.send_to_robot = null
 
     this.express_app = express()


### PR DESCRIPTION
After changing the configuration of servos via the browser UI, clicking the Done button on the Choose servo dialog will automatically reload the servo configuration for rq_core.

Tested by clicking the button and verifying the roboquest base node existed and was restarted.

Requires [rq_core PR 50}(https://github.com/billmania/roboquest_core/pull/50).