### PR TITLE
Prevented user-select globally

### DIFF
--- a/public/css/index.css
+++ b/public/css/index.css
@@ -9,6 +9,7 @@ html, body{
     color: #CC894E;
     line-height: 1.5;
     overflow-x: hidden;
+    user-select: none;
 }
 
 .full-height{


### PR DESCRIPTION
Just a simple one line fix. Note, this does not inhibit users from selecting input boxes and other things where that feature is important.