### PR TITLE
Replaced max_speed with max_rpm for motor speed slider widget

### DIFF
--- a/public/config/configuration.json
+++ b/public/config/configuration.json
@@ -426,9 +426,9 @@
       },
       "format": {
         "min": 0,
-        "max": 100,
+        "max": 300,
         "step": 5,
-        "default": 100,
+        "default": 300,
         "orientation": "horizontal",
         "animate": "true"
       },
@@ -436,7 +436,7 @@
         "topicDirection": "publish",
         "topic": "motor_speed",
         "topicType": "rq_msgs/msg/MotorSpeed",
-        "topicAttribute": "max_speed"
+        "topicAttribute": "max_rpm"
       },
       "type": "slider",
       "label": "MotorSpeed",

--- a/public/js/rq_params.js
+++ b/public/js/rq_params.js
@@ -12,7 +12,7 @@
 
 const RQ_PARAMS = {}
 
-RQ_PARAMS.VERSION = '20'
+RQ_PARAMS.VERSION = '21'
 
 RQ_PARAMS.CONFIG_FORMAT_VERSION = '6'
 RQ_PARAMS.CONFIG_FILE = 'persist/configuration.json'

--- a/src/params.js
+++ b/src/params.js
@@ -8,7 +8,7 @@
 const path = require('path')
 
 const RQ_PARAMS = {}
-RQ_PARAMS.VERSION = '20'
+RQ_PARAMS.VERSION = '21'
 
 RQ_PARAMS.CONFIG_FORMAT_VERSION = '6'
 RQ_PARAMS.SERVER_STATIC_DIR = path.join(

--- a/src/robot_comms.js
+++ b/src/robot_comms.js
@@ -155,7 +155,7 @@ class RobotComms {
         this.publishers[name].publish(rosMessage)
       } catch (error) {
         this.logger.warn(
-          `handle_payload: ${error}, name:${name}, payload:${JSON.stringify(rosMessage)}`
+          `handle_payload: ${error}, name:${name}, rosMessage:${JSON.stringify(rosMessage)}`
         )
       }
     } else if (this.services.includes(name)) {


### PR DESCRIPTION
The MotorSpeed message used to set the maximum speed of the drive motors had the attribute max_speed changed to max_rpm. The motor speed slider widget in the default configuration.json was updated with this new name. Also changed the maximum and default value for the slider from 100 to 300.

Tested by starting the containers, using ros2 topic to echo the /motor_speed topic, and then moving the motor speed slider widget. Observed the correct values being published onto the topic by the NodeJS server.

This is rq_ui Issue #114 and requires both [rq_msgs PR 7]() and [rq_core PR 54](https://github.com/billmania/roboquest_core/pull/54).