### PR TITLE
Added logging and verification related to configuration.json

### DIFF
--- a/public/js/rq_params.js
+++ b/public/js/rq_params.js
@@ -12,7 +12,7 @@
 
 const RQ_PARAMS = {}
 
-RQ_PARAMS.VERSION = '21'
+RQ_PARAMS.VERSION = '22rc1'
 
 RQ_PARAMS.CONFIG_FORMAT_VERSION = '6'
 RQ_PARAMS.CONFIG_FILE = 'persist/configuration.json'

--- a/src/config_file.js
+++ b/src/config_file.js
@@ -24,6 +24,12 @@ class ConfigFile {
    */
   _setup_config () {
     if (fs.existsSync(RQ_PARAMS.CONFIG_FILE)) {
+      /*
+       * N possiblities here:
+       * 1. the config file is valid and the correct version
+       * 2. the config file is non-empty but also non-parseable
+       * 3. the config file is empty
+       */
       const configuration = this.get_config()
 
       if (configuration.version === RQ_PARAMS.CONFIG_FORMAT_VERSION) {
@@ -47,6 +53,12 @@ class ConfigFile {
    * Any existing previous configuration file is removed. The existing
    * configuration file is moved to the .old file. Lastly, the configuration
    * object is stringified and written.
+   *
+   * Based upon:
+   * https://nodejs.org/docs/latest-v18.x/api/fs.html#fs_fs_existssync_path
+   * https://nodejs.org/docs/latest-v18.x/api/fs.html#fsrmsyncpath-options
+   * https://nodejs.org/docs/latest-v18.x/api/fs.html#fsrenamesyncoldpath-newpath
+   * https://nodejs.org/docs/latest-v18.x/api/fs.html#fswritefilesyncfile-data-options
    *
    * This is a synchronous call, so it's expensive.
    *
@@ -77,10 +89,19 @@ class ConfigFile {
     if (!configuration.version) {
       configuration.version = RQ_PARAMS.CONFIG_FORMAT_VERSION
     }
-    fs.writeFileSync(
-      RQ_PARAMS.CONFIG_FILE,
-      JSON.stringify(configuration, null, '  ')
-    )
+    try {
+      fs.writeFileSync(
+        RQ_PARAMS.CONFIG_FILE,
+        JSON.stringify(configuration, null, '  '),
+        {
+          encoding: 'utf8',
+          flag: 'w'
+        }
+      )
+    } catch (error) {
+      console.error(`save_config: Save failed> ${error}`)
+      return false
+    }
 
     return true
   }
@@ -119,7 +140,11 @@ class ConfigFile {
     }
     fs.writeFileSync(
       RQ_PARAMS.SERVO_FILE,
-      JSON.stringify(configuration, null, '  ')
+      JSON.stringify(configuration, null, '  '),
+      {
+        encoding: 'utf8',
+        flag: 'w'
+      }
     )
 
     return true
@@ -127,14 +152,40 @@ class ConfigFile {
 
   /**
    * Retrieve the configuration from the file in the persistence
-   * directory and return it as an object.
+   * directory and return it as an object. This method is expected
+   * to be called ONLY after the RQ_PARAMS.CONFIG_FILE has been
+   * shown (or caused) to exist.
+   *
+   * Verify the configuration file is:
+   * 1. not empty
+   * 2. parseable
    *
    * @returns {object} - the configuration
    */
   get_config () {
-    const configuration = fs.readFileSync(RQ_PARAMS.CONFIG_FILE)
+    const configuration = fs.readFileSync(
+      RQ_PARAMS.CONFIG_FILE,
+      {
+        encoding: 'utf8'
+      })
 
-    return JSON.parse(configuration)
+    if (configuration.length === 0) {
+      console.error('get_config: Configuration file is empty')
+      throw new Error('Configuration file is empty')
+    }
+
+    let configurationObj = null
+    try {
+      configurationObj = JSON.parse(configuration)
+      if (!Object.hasOwn(configurationObj, 'version')) {
+        throw new Error('No version property')
+      }
+    } catch (error) {
+      console.error(`get_error: Parse failed ${error}`)
+      throw new Error('Parse failed')
+    }
+
+    return configurationObj
   }
 }
 

--- a/src/params.js
+++ b/src/params.js
@@ -8,7 +8,7 @@
 const path = require('path')
 
 const RQ_PARAMS = {}
-RQ_PARAMS.VERSION = '21'
+RQ_PARAMS.VERSION = '22rc1'
 
 RQ_PARAMS.CONFIG_FORMAT_VERSION = '6'
 RQ_PARAMS.SERVER_STATIC_DIR = path.join(


### PR DESCRIPTION
A inconsistently reproducible exists where the configuration.json file is corrupted after saving an updated version and removing power from the Rasp Pi without performing a clean shutdown. No clear cause was found for this issue. More logging and verification was added in an attempt to have more telemetry and evidence when the condition occurs.

Also, [rq_core PR 57](https://github.com/billmania/roboquest_core/pull/57) and [rq_core PR 58](https://github.com/billmania/roboquest_core/pull/58) were created to help with this condition.

https://github.com/billmania/roboquest_ui/issues/112