### PR TITLE
Simultaneous key presses for the joystick widget

### DIFF
--- a/public/config/README_configuration.md
+++ b/public/config/README_configuration.md
@@ -132,14 +132,15 @@ the widget properties have the following sections:
 * data.topicPeriodS: (joystick) Only when data.topicDirection is "publish",
                                 the browser UI will continually publish the
                                 current value with a period of
-                                data.topicPeriodS seconds
+                                data.topicPeriodS seconds. set to 0 to disable.
   
 * data.service: (button) ROS service to call
 * data.serviceType: (button) ROS service type of the service
 * data.serviceAttribute: (button) ROS service attribute to set
 * data.clickValue: (button) value when button is clicked
 
-* data.scale : (joystick) floating point values array [x, y]
+* data.scale : (joystick) floating point values array [x, y] used to scale
+*                         the joystick axis values.
 
 * keys: how keycodes map to widget actions. individual keycodes may only appear once
         in the configuration file. the quantity of keycodes per widget is limited

--- a/public/index.htm
+++ b/public/index.htm
@@ -172,6 +172,8 @@
                 <label>topic:</label> <input type="text" data-section="data" class="socket" value="" name="topic"><br/>
                 <label>topic type:</label> <input type="text" data-section="data" class="socket" value="" name="topicType"><br/>
                 <label>topic attribute:</label> <input type="text" data-section="data" class="socket" value="" name="topicAttribute"><br/>
+                <label>axes scaling:</label> <input type="text" data-section="data" class="socket" value="" name="scale"><br/>
+                <label>topic period:</label> <input type="number" data-section="data" class="socket" value="" name="topicPeriodS"><br/>
             </div>
         </form>
     </div>

--- a/public/js/key_control.js
+++ b/public/js/key_control.js
@@ -622,10 +622,6 @@ class KeyControl { // eslint-disable-line no-unused-vars
       return
     }
 
-    if (this._keyToWidget[whichKey].widgetType === 'joystick') {
-      console.debug(`_keyHandler: called with joystick key ${whichKey}`)
-    }
-
     let values
     if (eventData.type === 'keydown' &&
         Object.hasOwn(this._keyToWidget[whichKey], 'downValues')) {

--- a/public/js/key_control.js
+++ b/public/js/key_control.js
@@ -27,6 +27,7 @@ class KeyControl { // eslint-disable-line no-unused-vars
   constructor (keyButtonId) {
     this._keyButtonId = keyButtonId
     this._keyToWidget = {}
+    this._widgetValues = {}
     this._keyableWidgets = []
     this._keysSet = []
     this._configureWidgetObj = null
@@ -430,11 +431,30 @@ class KeyControl { // eslint-disable-line no-unused-vars
    */
   _mapKeyToWidget (key, widgetId, widgetType, downValues, upValues) {
     if (!Object.hasOwn(this._keyToWidget, key)) {
-      this._keyToWidget[key] = {
-        widgetId,
-        widgetType,
-        downValues,
-        upValues
+      if (widgetType !== 'joystick') {
+        this._keyToWidget[key] = {
+          widgetId,
+          widgetType,
+          downValues,
+          upValues
+        }
+      } else {
+        /*
+         * Joystick widgets allow multiple keys to be pressed
+         * simultaneously. latestValues keeps track of this key's
+         * latest downValues.
+         */
+        this._keyToWidget[key] = {
+          widgetId,
+          widgetType,
+          downValues,
+          upValues,
+          latestValues: { x: 0, y: 0 }
+        }
+        this._widgetValues[widgetId] = {
+          x: 0,
+          y: 0
+        }
       }
     } else {
       console.error(
@@ -534,8 +554,63 @@ class KeyControl { // eslint-disable-line no-unused-vars
   }
 
   /**
-   * Based on the key specified in eventData.which, call the associated widget's
-   * valueHandler.
+   * Based on the widgetType and the direction, calculate the values
+   * to send to the widget's valuesHandler function.
+   *
+   * keydown events can repeat. The downValues for the key must be applied
+   * only once before a keyup event occurs. keyup events don't repeat.
+   *
+   * @param {string} widgetType
+   * @param {string} widgetId
+   * @param {number} whichKey
+   * @param {string} direction - 'up' or 'down'
+   * @param {Array} values
+   */
+  _applyValues (widgetType, widgetId, whichKey, direction, values) {
+    if (widgetType !== 'joystick') {
+      return values
+    }
+
+    if (direction === 'down') {
+      if (this._keyToWidget[whichKey].latestValues.x === 0 &&
+          this._keyToWidget[whichKey].latestValues.y === 0) {
+        this._keyToWidget[whichKey].latestValues.x = values.x
+        this._keyToWidget[whichKey].latestValues.y = values.y
+        this._widgetValues[widgetId].x += values.x
+        this._widgetValues[widgetId].y += values.y
+      }
+    } else {
+      /*
+       * Handle the keyup event. A keyup event will normally set
+       * all values to 0. That must cause the key's values to be
+       * subtracted from _widgetValues. If the keyup values are
+       * instead non-zero, latestValues must first be subtracted
+       * from _widgetValues. Then _latestValues are set to the
+       * keyup values and finally the keyup values are added
+       * to _widgetValues.
+       */
+      this._widgetValues[widgetId].x -= this._keyToWidget[whichKey].latestValues.x
+      this._widgetValues[widgetId].y -= this._keyToWidget[whichKey].latestValues.y
+      if (values.x === 0 && values.y === 0) {
+        this._keyToWidget[whichKey].latestValues.x = 0
+        this._keyToWidget[whichKey].latestValues.y = 0
+      } else {
+        this._keyToWidget[whichKey].latestValues.x = values.x
+        this._keyToWidget[whichKey].latestValues.y = values.y
+        this._widgetValues[widgetId].x += values.x
+        this._widgetValues[widgetId].y += values.y
+      }
+    }
+
+    return this._widgetValues[widgetId]
+  }
+
+  /**
+   * Based on the key specified in eventData.which, first determine the
+   * type of widget to which this key is assigned. Then, call the
+   * associated widget's valueHandler function.
+   * Keys assigned to joystick widgets have special handling because
+   * multiple keys are allowed to be pressed simultaneously.
    *
    * @param {object} eventData - the event type and the specific key
    */
@@ -547,26 +622,41 @@ class KeyControl { // eslint-disable-line no-unused-vars
       return
     }
 
+    if (this._keyToWidget[whichKey].widgetType === 'joystick') {
+      console.debug(`_keyHandler: called with joystick key ${whichKey}`)
+    }
+
     let values
     if (eventData.type === 'keydown' &&
         Object.hasOwn(this._keyToWidget[whichKey], 'downValues')) {
-      values = this._keyToWidget[whichKey].downValues
+      values = this._applyValues(
+        this._keyToWidget[whichKey].widgetType,
+        this._keyToWidget[whichKey].widgetId,
+        whichKey,
+        'down',
+        this._keyToWidget[whichKey].downValues
+      )
     } else if (eventData.type === 'keyup' &&
                Object.hasOwn(this._keyToWidget[whichKey], 'upValues')) {
-      values = this._keyToWidget[whichKey].upValues
+      values = this._applyValues(
+        this._keyToWidget[whichKey].widgetType,
+        this._keyToWidget[whichKey].widgetId,
+        whichKey,
+        'up',
+        this._keyToWidget[whichKey].upValues
+      )
     } else {
       console.error(
         `No values defined for ${this._keyToWidget[whichKey].widgetId}` +
         ` and ${whichKey}`)
+      return
     }
 
-    if (values) {
-      jQuery('#' + this._keyToWidget[whichKey].widgetId)
-        .data(
-          RQ_PARAMS.WIDGET_NAMESPACE +
-          '-' +
-          this._keyToWidget[whichKey].widgetType.toUpperCase())
-        .valuesHandler(values)
-    }
+    jQuery('#' + this._keyToWidget[whichKey].widgetId)
+      .data(
+        RQ_PARAMS.WIDGET_NAMESPACE +
+        '-' +
+        this._keyToWidget[whichKey].widgetType.toUpperCase())
+      .valuesHandler(values)
   }
 }

--- a/public/js/key_help.js
+++ b/public/js/key_help.js
@@ -6,14 +6,14 @@
 
 const RQKeysHelp = {}
 
-RQKeysHelp.version = 3
+RQKeysHelp.version = 4
 
 RQKeysHelp.keycodes = 'To change or set a key, click on the key name in the Key column and then press and release the keyboard key. If the new key is not assigned to another widget, the name will change.'
 
 RQKeysHelp.done = 'When finished making changes, click the Apply button. To make the changes permanent, click "save config" in Configuration settings.'
 
-RQKeysHelp.joystick = 'The joystick widget produces two number values, x and y. y is the position of the joystick forward and backward. x is the position side to side. The range for both x and y is [-100, 100]. When assigning a key to the joystick, specify the x and y values like "x: 50, y:0" where 50 and 0 can be any value in [-100, 100].' + '   ' + RQKeysHelp.keycodes + ' ' + RQKeysHelp.done
+RQKeysHelp.joystick = 'The joystick widget produces two number values, x and y. y is the position of the joystick forward and backward. x is the position side to side. The range for both x and y is [-100, 100]. When assigning a key to the joystick, specify the x and y values like "x:50, y:0" where 50 and 0 can be any value in [-100, 100].' + '   ' + RQKeysHelp.keycodes + ' ' + RQKeysHelp.done
 
 RQKeysHelp.button = 'The button widget only produces a click event - it doesn\'t produce any value itself. The ON Press and On Release fields are ignored.' + '   ' + RQKeysHelp.keycodes + ' ' + RQKeysHelp.done
 
-RQKeysHelp.slider = 'The slider widget produces a single value in the range defined when the widget was configured. When assigning a key to the slider, specify the On Press and/or On Release like "name:Whatever,value:4" where Whatever is a name of your choosing and 4 is any number in range.' + '   ' + RQKeysHelp.keycodes + ' ' + RQKeysHelp.done
+RQKeysHelp.slider = 'The slider widget produces a single value in the range defined when the widget was configured. When assigning a key to the slider, specify the On Press and/or On Release like "name:<name>,value:<value>". For a servo, <name> is the widget label and <value> is an appropriate positive or negative angle increment.' + '   ' + RQKeysHelp.keycodes + ' ' + RQKeysHelp.done

--- a/public/js/rq_params.js
+++ b/public/js/rq_params.js
@@ -12,7 +12,7 @@
 
 const RQ_PARAMS = {}
 
-RQ_PARAMS.VERSION = '24'
+RQ_PARAMS.VERSION = '25'
 
 RQ_PARAMS.CONFIG_FORMAT_VERSION = '7'
 RQ_PARAMS.CONFIG_FILE = 'persist/configuration.json'

--- a/public/js/wJoystick.js
+++ b/public/js/wJoystick.js
@@ -33,7 +33,7 @@ jQuery.widget(RQ_PARAMS.WIDGET_NAMESPACE + '.JOYSTICK', {
    * There is a bit of complexity due to the different way the Joystick and KeyControl
    * send their axesData. The Joystick only calls valuesHandler() when the position of
    * the joystick knob moves. KeyControl calls valuesHandler repeatedly as long as the
-   * key is depressed, because the OS/browser repeat the keycode for a depressed key.
+   * key is depressed, because the OS/browser repeats the keycode for a depressed key.
    * Further complicating matters is the setInterval() based on topicPeriodS from the
    * configuration.
    *
@@ -41,7 +41,15 @@ jQuery.widget(RQ_PARAMS.WIDGET_NAMESPACE + '.JOYSTICK', {
    * calls to _triggerSocketEvent - once for each repeated key event and once for every
    * topicPeriodS interval. The skipAnInterval option is provided to deal with this.
    *
-   * @param {object} axisData - an object with two properties, x and y.
+   * @param {object} axesData - an object describing the joystick state. Joystick
+   *                            calls with the object
+   *                              {"xPosition":109,
+   *                               "yPosition":71,
+   *                               "x":"18",
+   *                               "y":"58",
+   *                               "cardinalDirection":"N"}
+   *                            while KeyControl calls with the object
+   *                              {"x":0,"y":0}.
    */
   valuesHandler: function (axesData) {
     if (this.options.currentAxes.x !== axesData.x ||
@@ -100,7 +108,7 @@ jQuery.widget(RQ_PARAMS.WIDGET_NAMESPACE + '.JOYSTICK', {
      * When topicPeriodS is a positive integer, periodically emit the axes values,
      * in case the previous emission was lost.
      */
-    if (this.options.data.topicPeriodS) {
+    if (this.options.data.topicPeriodS > 0) {
       this._repeater = setInterval(
         () => {
           if (this.options.skipAnInterval) {

--- a/public/js/wJoystick.js
+++ b/public/js/wJoystick.js
@@ -1,6 +1,8 @@
 'use strict'
 /* global jQuery, RQ_PARAMS, JoyStick */
 
+const JOYSTICK_DEFAULT_SCALING = [1.0, 1.0]
+
 /**
  * A joystick for providing two values based on the position of the joystick
  * knob. Typically used to drive the robot. The x-axis value is always
@@ -51,11 +53,38 @@ jQuery.widget(RQ_PARAMS.WIDGET_NAMESPACE + '.JOYSTICK', {
     }
   },
 
-  _create: function () {
-    if (!this.options.data.scale) {
-      this.options.data.scale = [1, 1]
+  /**
+   * Process the "scale" option. If no scale was provided, set its default
+   * value to JOYSTICK_DEFAULT_SCALING. If it was provided as two strings,
+   * convert each to a float when required or an int when possible.
+   *
+   * @param {Array} scaling - the configured scaling
+   *
+   * @returns {Array} - a two member Array with the scaling values as numbers
+   */
+  _setupScaling: function (scaling) {
+    if (!Array.isArray(scaling) ||
+        scaling.length !== 2) {
+      scaling = JOYSTICK_DEFAULT_SCALING
     }
+
+    scaling.forEach(function (item, index) {
+      if (typeof item !== 'number') {
+        scaling[index] = parseFloat(item)
+        if (isNaN(scaling[index])) {
+          scaling[index] = 1
+        }
+      }
+    })
+
+    return scaling
+  },
+
+  _create: function () {
     const objContent = jQuery('<div id="joystick" style="width:200px; height:200px"></div>')
+
+    this.options.data.scale = this._setupScaling(this.options.data.scale)
+    this.options.data.topicPeriodS = parseFloat(this.options.data.topicPeriodS)
 
     this.element.children('.widget-content').html(objContent).ready(
       () => {

--- a/public/js/widget_config.js
+++ b/public/js/widget_config.js
@@ -346,8 +346,9 @@ const extractWidgetConfigurationFromDialog = function () {
         }
         if (strPropSection === 'data') {
           /*
-             * The topicAttribute element may contain multiple attributes.
-             * When found, assemble them into an Array of strings.
+             * Elements, such as topicAttribute and scale, may contain
+             * multiple items. When found, assemble them into an Array
+             * of strings.
              */
           if (element.value.indexOf(RQ_PARAMS.ATTR_DELIMIT) > -1) {
             const attributes = element.value
@@ -497,6 +498,8 @@ const widgetDefaults = {
     label: 'joystickX',
     format: {},
     data: {
+      scale: '1;1',
+      topicPeriodS: 3,
       topicDirection: 'publish',
       topic: 'cmd_vel',
       topicType: 'rq_msgs/msg/TwistStamped',

--- a/src/params.js
+++ b/src/params.js
@@ -8,7 +8,7 @@
 const path = require('path')
 
 const RQ_PARAMS = {}
-RQ_PARAMS.VERSION = '24'
+RQ_PARAMS.VERSION = '25'
 
 RQ_PARAMS.CONFIG_FORMAT_VERSION = '7'
 RQ_PARAMS.SERVER_STATIC_DIR = path.join(


### PR DESCRIPTION
The joystick widget can handle multiple of its configured keys depressed before any depressed key is released. The effect of the depressed keys is summed. This will work best when the upValues for each key are all zero. However, it is possible to define non-zero values for the upValues and that key can be depressed simultaneously with others, but it's not possible to undo the effect of the upValues.

As part of this change, the scale and topicPeriodS configuration options for the joystick were added to the add and reconfigure dialogs.

Covers Issue #119 
