### PR TITLE
Preserve joystick key configurations after joystick reconfiguration

### DIFF
--- a/public/js/wJoystick.js
+++ b/public/js/wJoystick.js
@@ -2,6 +2,11 @@
 /* global jQuery, RQ_PARAMS, JoyStick */
 
 const JOYSTICK_DEFAULT_SCALING = [1.0, 1.0]
+/*
+ * joystickIntervalId is global so any previous setInterval() can be cleared
+ * just before reconfiguring the joystick widget.
+ */
+let joystickIntervalId = null
 
 /**
  * A joystick for providing two values based on the position of the joystick
@@ -109,7 +114,12 @@ jQuery.widget(RQ_PARAMS.WIDGET_NAMESPACE + '.JOYSTICK', {
      * in case the previous emission was lost.
      */
     if (this.options.data.topicPeriodS > 0) {
-      this._repeater = setInterval(
+      if (joystickIntervalId) {
+        clearInterval(joystickIntervalId)
+        joystickIntervalId = null
+      }
+
+      joystickIntervalId = setInterval(
         () => {
           if (this.options.skipAnInterval) {
             this.options.skipAnInterval = false

--- a/public/js/widget_config.js
+++ b/public/js/widget_config.js
@@ -235,6 +235,15 @@ const reconfigureWidget = function (oldWidgetConfig, newWidgetConfig) {
 
   newWidgetConfig.position = oldWidgetConfig.position
   createWidget(newWidgetConfig)
+  if (Object.hasOwn(oldWidgetConfig, 'keys')) {
+    /*
+     * The configuration of widgets keys is handled separately from
+     * the configuration of the widget itself. Therefore the keys
+     * configuration must be preserved here.
+     */
+    newWidgetConfig.keys = oldWidgetConfig.keys
+    keyControl.rebuildKeyMap()
+  }
   positionWidgets()
 }
 


### PR DESCRIPTION
The recently added logic to support reconfiguring a widget did not preserve the old widget's key assignments. They are now being preserved.

Also stopped the JavaScript interval which was continuously publishing joystick values just before replacing the old joystick with the new configuration joystick. At the same time, added some logic to only publish joystick axes values when they change, intended to protect the topic and node from the high-frequency repeat of depressed keys. The interval will publish the values even when they haven't changed.

https://github.com/billmania/roboquest_ui/issues/126