### PR TITLE
Joystick widget add, delete, and reconfig

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "debug": "~2.6.9",
         "express": "^4.18.2",
         "http": "^0.0.1-security",
+        "lodash.clonedeep": "^4.5.0",
         "lodash.set": "^4.3.2",
         "morgan": "^1.10.0",
         "path": "^0.12.7",
@@ -3030,6 +3031,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ=="
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",

--- a/package.json
+++ b/package.json
@@ -16,11 +16,12 @@
     "debug": "~2.6.9",
     "express": "^4.18.2",
     "http": "^0.0.1-security",
+    "lodash.clonedeep": "^4.5.0",
+    "lodash.set": "^4.3.2",
     "morgan": "^1.10.0",
     "path": "^0.12.7",
     "rclnodejs": "^0.22.1",
-    "socket.io": "^4.6.1",
-    "lodash.set": "^4.3.2"
+    "socket.io": "^4.6.1"
   },
   "devDependencies": {
     "eslint": "^8.40.0",

--- a/public/config/README_joystick.md
+++ b/public/config/README_joystick.md
@@ -1,0 +1,144 @@
+# Joystick capabilities and configuration
+
+## General
+The Joystick widget is the most complex widget available. It
+always produces two numerical values. Typically, it's used to
+command two-dimensional robot motion. It can be used in
+place of a non-servo slider, as well as anywhere two values are
+needed within a single ROS message. Lastly, it's possible to use
+a single joystick to command one servo.
+
+## Configuration options
+
+### topic direction
+
+A joystick can only "publish" onto a topic.
+
+### topic
+
+The name of the topic onto which the value(s) should be published.
+For example, to command robot motion, the topic is "cmd_vel".
+
+### topic type
+
+The type of ROS message to publish. For the "cmd_vel" topic, the
+type is "geometry_msgs/msg/TwistStamped".
+
+### topic attribute
+
+Since the joystick produces two numerical values, one or two
+attributes can be specified. The joystick's numerical values are
+in order with the x axis first and the y axis second. The x axis
+value is assigned to the first attribute. If a second attribute
+is specified, the y axis value is assigned to it.
+
+The first attribute name must be terminated with a semi-colon,
+even when there is no second attribute.
+For example, "twist.angular.z;twist.linear.x" or "max_rpm;".
+
+### axes scaling
+
+Joystick axes values are always within the range [-100, 100]. The
+two scaling values are floating point and will scale the axis
+values. For example, if the attribute to which the x axis value
+will be assigned requires a value in the range [-300, 300] then
+set the x scaling value to 3.
+
+Two scaling values are required and they must be separated by a
+semi-colon. The default scaling is "1;1", which doesn't actually
+scale.
+
+### topic period
+
+The joystick has the option of automatically republishing its
+most recent values. If this is not required, set the period to 0.
+If it's necessary to republish values, set the topic period in
+seconds.
+
+## Examples from configuration.json
+
+### motion command
+
+```
+{
+  "id": 18,
+  "type": "joystick",
+  "label": "motion",
+  "position": {
+  "my": "left top",
+  "at": "left top"
+  },
+  "format": {},
+  "data": {
+    "scale": [
+      1,
+      1
+    ],
+    "topic": "cmd_vel",
+    "topicAttribute": [
+      "twist.angular.z",
+      "twist.linear.x"
+    ],
+    "topicType": "geometry_msgs/msg/TwistStamped",
+    "topicDirection": "publish",
+    "topicPeriodS": 5
+  }
+}
+```
+
+## simple slider
+
+```
+    {
+      "position": {
+        "my": "left top",
+        "at": "left top"
+      },
+      "format": {},
+      "data": {
+        "topicDirection": "publish",
+        "topic": "motor_speed",
+        "topicType": "rq_msgs/msg/MotorSpeed",
+        "topicAttribute": [
+          "max_rpm",
+          ""
+        ],
+        "scale": [
+          1,
+          0
+        ],
+        "topicPeriodS": "0"
+      },
+      "type": "joystick",
+      "label": "MotorSpeed2",
+      "id": 22
+    }
+```
+
+## servo
+
+```
+    {
+      "position": {
+        "my": "left top",
+        "at": "left top"
+      },
+      "format": {},
+      "data": {
+        "topicDirection": "publish",
+        "topic": "servos",
+        "topicType": "rq_msgs/msg/ServoAngles",
+        "topicAttribute": [
+          "name:0",
+          "angle"
+        ],
+        "scale": [
+          0,
+          1.8
+        ],
+        "topicPeriodS": "0"
+      },
+      "type": "joystick",
+      "label": "camera_pan2"
+    },
+```

--- a/public/config/configuration.json
+++ b/public/config/configuration.json
@@ -280,7 +280,7 @@
     {
       "id": 18,
       "type": "joystick",
-      "label": "Joystick",
+      "label": "drive",
       "position": {
         "my": "left top",
         "at": "left+-21 top+879.0999755859375"
@@ -372,8 +372,7 @@
           "angle",
           "name"
         ],
-        "topicType": "rq_msgs/msg/ServoAngles",
-        "topicPeriodS": 3
+        "topicType": "rq_msgs/msg/ServoAngles"
       },
       "keys": {
         "81": {
@@ -417,8 +416,7 @@
           "angle",
           "name"
         ],
-        "topicType": "rq_msgs/msg/ServoAngles",
-        "topicPeriodS": 3
+        "topicType": "rq_msgs/msg/ServoAngles"
       }
     },
     {

--- a/public/css/index.css
+++ b/public/css/index.css
@@ -219,11 +219,13 @@ input, select{
 }
 
 /* 
- * jQuery adds this class to the #trash element when a widget is hovering over the trash.
- * The important flag is used to overwrite the background attribute in the #trash style when this class is applied.
- * Though the use of the important flag can lead to complications when multiple styles are applied to the same element,
- * it's perfectly fine for a simple trash bin with two states.
+ * jQuery adds this class to the #trash element when a widget is hovering
+ * over the trash. The important flag is used to overwrite the background
+ * attribute in the #trash style when this class is applied. Though the
+ * use of the "important" flag can lead to complications when multiple
+ * styles are applied to the same element, it's perfectly fine for a
+ * simple trash bin with two states.
  */
 .trash-drop-hover{
-    background-color: #5e0000 !important; 
+    background-color: #ccff66 !important; 
 }

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -266,8 +266,6 @@ jQuery(function () {
     },
     drop: function (event, ui) {
       ui.draggable.remove()
-      console.debug('dropped ID ', ui.draggable.getWidgetConfiguration().id)
-      // TODO: Not sure positionWidgets is required here
       positionWidgets()
     }
   })

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -265,8 +265,8 @@ jQuery(function () {
       'ui-droppable-hover': 'trash-drop-hover'
     },
     drop: function (event, ui) {
-      console.debug('dropped ID ', ui.draggable.getWidgetConfiguration().id)
       ui.draggable.remove()
+      console.debug('dropped ID ', ui.draggable.getWidgetConfiguration().id)
       // TODO: Not sure positionWidgets is required here
       positionWidgets()
     }

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -260,6 +260,7 @@ jQuery(function () {
 
   jQuery('#trash').droppable({
     accept: '.widget',
+    tolerance: 'pointer',
     classes: {
       'ui-droppable-hover': 'trash-drop-hover'
     },

--- a/public/js/rq_params.js
+++ b/public/js/rq_params.js
@@ -12,7 +12,7 @@
 
 const RQ_PARAMS = {}
 
-RQ_PARAMS.VERSION = '25'
+RQ_PARAMS.VERSION = '26'
 
 RQ_PARAMS.CONFIG_FORMAT_VERSION = '7'
 RQ_PARAMS.CONFIG_FILE = 'persist/configuration.json'

--- a/public/js/rq_params.js
+++ b/public/js/rq_params.js
@@ -22,8 +22,14 @@ RQ_PARAMS.MESSAGE_DURATION_S = 15
 RQ_PARAMS.UPDATE_FORMAT_VERSION = 1
 RQ_PARAMS.DISCONNECTED_IMAGE = 'img/background.jpg'
 
-// multiple topic attributes are delimited with this character
+// topic attributes are delimited with this character
 RQ_PARAMS.ATTR_DELIMIT = ';'
+/*
+ * When an attribute is to always be assigned a constant,
+ * use this character to separate the attribute name from
+ * the constant.
+ */
+RQ_PARAMS.VALUE_DELIMIT = ':'
 
 // TODO: Implement use of this in public/js/index.js
 RQ_PARAMS.WIDGET_NAMESPACE = 'rq'

--- a/public/js/wJoystick.js
+++ b/public/js/wJoystick.js
@@ -104,6 +104,16 @@ jQuery.widget(RQ_PARAMS.WIDGET_NAMESPACE + '.JOYSTICK', {
     return scaling
   },
 
+  /**
+   * How to cleanup before deleting the widget.
+   */
+  _destroy: function () {
+    if (Object.hasOwn(joystickIntervalId, this.options.label)) {
+      clearInterval(joystickIntervalId[this.options.label])
+      delete joystickIntervalId[this.options.label]
+    }
+  },
+
   _create: function () {
     const divId = this.options.label + '-div'
     const objContent = jQuery(

--- a/public/js/wJoystick.js
+++ b/public/js/wJoystick.js
@@ -6,12 +6,7 @@ const JOYSTICK_DEFAULT_SCALING = [1.0, 1.0]
  * joystickIntervalId is global so any previous setInterval() can be cleared
  * just before reconfiguring the joystick widget.
  */
-/*
- * TODO: Enhance this to handle multiple Joystick instances
- * Convert it to an object with a property for each unique
- * this.options.label.
- */
-let joystickIntervalId = null
+const joystickIntervalId = {}
 
 /**
  * A joystick for providing two values based on the position of the joystick
@@ -136,12 +131,12 @@ jQuery.widget(RQ_PARAMS.WIDGET_NAMESPACE + '.JOYSTICK', {
      * the axes values, in case the previous emission was lost.
      */
     if (this.options.data.topicPeriodS > 0) {
-      if (joystickIntervalId) {
-        clearInterval(joystickIntervalId)
-        joystickIntervalId = null
+      if (Object.hasOwn(joystickIntervalId, this.options.label)) {
+        clearInterval(joystickIntervalId[this.options.label])
+        delete joystickIntervalId[this.options.label]
       }
 
-      joystickIntervalId = setInterval(
+      joystickIntervalId[this.options.label] = setInterval(
         () => {
           if (this.options.skipAnInterval) {
             this.options.skipAnInterval = false

--- a/public/js/wJoystick.js
+++ b/public/js/wJoystick.js
@@ -159,6 +159,38 @@ jQuery.widget(RQ_PARAMS.WIDGET_NAMESPACE + '.JOYSTICK', {
     }
   },
 
+  /**
+   * Assign a value to a specific attribute. This function
+   * modifies its first argument.
+   *
+   * @param {object} payload - the payload object
+   * @param {number} attrIndex - which attribute
+   * @param {number} value - axis value to assign
+   */
+  _assignValue: function (payload, attrIndex, value) {
+    if (this.options.data.topicAttribute[attrIndex] !== '') {
+      if (this.options.data.topicAttribute[attrIndex].indexOf(
+        RQ_PARAMS.VALUE_DELIMIT) === -1) {
+        payload[this.options.data.topicAttribute[attrIndex]] = (
+          value * this.options.data.scale[attrIndex]
+        )
+      } else {
+        const nameAndValue = this.options.data.topicAttribute[attrIndex]
+          .split(RQ_PARAMS.VALUE_DELIMIT)
+        payload[nameAndValue[0]] = nameAndValue[1]
+      }
+    }
+  },
+
+  /**
+   * Assemble a payload from the axisValues based on the
+   * contents of this.options.data.topicAttribute. There
+   * can be one or two attributes. The x value is always
+   * assigned to the first attribute, if it exists. y is
+   * always assigned to the second, if it exists.
+   * An attribute can also have a constant value assinged
+   * to it.
+   */
   _triggerSocketEvent: function (event, axisValues) {
     const objPayload = {}
     if (!axisValues) {
@@ -166,12 +198,17 @@ jQuery.widget(RQ_PARAMS.WIDGET_NAMESPACE + '.JOYSTICK', {
       return
     }
 
-    objPayload[this.options.data.topicAttribute[0]] = (
-      axisValues.x * this.options.data.scale[0]
+    console.debug(
+      '_triggerSocketEvent:' +
+      ` axisValues: ${JSON.stringify(axisValues)}`
     )
-    objPayload[this.options.data.topicAttribute[1]] = (
-      axisValues.y * this.options.data.scale[1]
-    )
+    console.debug(
+      '_triggerSocketEvent:' +
+      ` topicAttribute: ${JSON.stringify(this.options.data.topicAttribute)}`)
+
+    this._assignValue(objPayload, 0, axisValues.x)
+    this._assignValue(objPayload, 1, axisValues.y)
+
     this.options.socket.emit(
       this.options.data.topic,
       JSON.stringify(objPayload)

--- a/public/js/wJoystick.js
+++ b/public/js/wJoystick.js
@@ -24,8 +24,13 @@ let joystickIntervalId = null
 jQuery.widget(RQ_PARAMS.WIDGET_NAMESPACE + '.JOYSTICK', {
   options: {
     socket: null,
+    /*
+     * joystick widget type doesn't have any "format" options.
+     */
+    format: {},
     data: {
-      format: {}
+      scale: [1, 1],
+      topicPeriodS: 5
     },
 
     /*
@@ -105,7 +110,7 @@ jQuery.widget(RQ_PARAMS.WIDGET_NAMESPACE + '.JOYSTICK', {
   },
 
   _create: function () {
-    const divId = this.options.label + '-joystick-div'
+    const divId = this.options.label + '-div'
     const objContent = jQuery(
       '<div id="' +
       divId +
@@ -115,7 +120,7 @@ jQuery.widget(RQ_PARAMS.WIDGET_NAMESPACE + '.JOYSTICK', {
     this.options.data.scale = this._setupScaling(this.options.data.scale)
     this.options.data.topicPeriodS = parseFloat(this.options.data.topicPeriodS)
 
-    const canvasId = this.options.label + '-joystick-canvas'
+    const canvasId = this.options.label + '-canvas'
     this.element.children('.widget-content').html(objContent).ready(
       () => {
         const objJoystick = new JoyStick( // eslint-disable-line no-unused-vars

--- a/public/js/wSlider.js
+++ b/public/js/wSlider.js
@@ -79,7 +79,7 @@ jQuery.widget(RQ_PARAMS.WIDGET_NAMESPACE + '.SLIDER', {
 
       let value = ui.value
       if (this.options.format.reversed.toLowerCase() === 'yes') {
-        value = [Math.abs(value - this.options.format.max) + this.options.format.min]
+        value = Math.abs(value - this.options.format.max) + this.options.format.min
       }
       /*
        * A slider may use one or two topicAttributes. When only one, it's

--- a/public/js/widget_config.js
+++ b/public/js/widget_config.js
@@ -126,8 +126,9 @@ const createWidget = function (objWidget) { // eslint-disable-line no-unused-var
   }
 
   /*
-   * Store the widget configuration object (objWidget) under the WIDGET_NAMESPACE
-   * in an arbetrary jQuery data unit attatched to the widgetContainer
+   * Store the widget configuration object (objWidget) under the
+   * WIDGET_NAMESPACE in an arbitrary jQuery data unit attached
+   * to the widgetContainer.
    */
   jQuery(widgetContainer).data(RQ_PARAMS.WIDGET_NAMESPACE, objWidget)
 
@@ -142,11 +143,7 @@ const createWidget = function (objWidget) { // eslint-disable-line no-unused-var
     snap: true,
     start: function (event, ui) {
       const widgetId = event.currentTarget.id
-      console.debug(
-        `drag started on ${widgetId}` +
-        ` at position ${JSON.stringify(jQuery('#' + widgetId).position())}` +
-        ` and offset ${JSON.stringify(jQuery('#' + widgetId).offset())}`
-      )
+      console.debug(`drag started on ${widgetId}`)
     },
     stop: function (event, ui) {
       const widgetId = event.target.id
@@ -154,8 +151,8 @@ const createWidget = function (objWidget) { // eslint-disable-line no-unused-var
 
       if (!widgetData) {
         /*
-         * The widgetData no longer exists, likely because the widget was deleted from the UI. That condition
-         * is acceptable here.
+         * The widgetData no longer exists, likely because the widget
+         * was deleted from the UI. That condition is acceptable here.
          */
         return
       }

--- a/public/js/widget_config.js
+++ b/public/js/widget_config.js
@@ -508,7 +508,7 @@ const widgetDefaults = {
       topicPeriodS: 3,
       topicDirection: 'publish',
       topic: 'cmd_vel',
-      topicType: 'rq_msgs/msg/TwistStamped',
+      topicType: 'geometry_msgs/msg/TwistStamped',
       topicAttribute: 'twist.angular.z;twist.linear.x'
     }
   }

--- a/scripts/release_docs.sh
+++ b/scripts/release_docs.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+set -x 
+
+#
+# Release the documentation files to the documentation server
+#
+
+DOC_SRC_BASE=~bill/projects/roboquest/ros2ws/src/roboquest_ui
+DOC_HOST=registry.q4excellence.com
+DOC_DIR=/var/www/html/docs
+DOC_USER=root
+
+cd ${DOC_SRC_BASE}
+DOCS=$(find . -type f -name '*.md' | grep -v README.md | grep -v node_mo)
+
+for doc_file in ${DOCS}
+do
+        html_file=$(echo ${doc_file} | sed -e 's/\.md$/.html/' -e 's/README_//')
+        pandoc --from=markdown_strict \
+               --to=html \
+               --output=${html_file} \
+               ${doc_file}
+        scp ${html_file} ${DOC_USER}@${DOC_HOST}:${DOC_DIR}/
+        rm ${html_file}
+done
+
+ssh ${DOC_USER}@${DOC_HOST} chown www-data:www-data ${DOC_DIR}/*
+
+exit 0

--- a/src/params.js
+++ b/src/params.js
@@ -8,7 +8,7 @@
 const path = require('path')
 
 const RQ_PARAMS = {}
-RQ_PARAMS.VERSION = '25'
+RQ_PARAMS.VERSION = '26'
 
 RQ_PARAMS.CONFIG_FORMAT_VERSION = '7'
 RQ_PARAMS.SERVER_STATIC_DIR = path.join(

--- a/src/robot_comms.js
+++ b/src/robot_comms.js
@@ -138,6 +138,9 @@ class RobotComms {
    *                           or widgetConfig.data.serviceAttribute(s)
    */
   handle_payload (name, payload) {
+    console.debug(
+      `handle_payload: name: ${name}` +
+      `, payload: ${JSON.stringify(payload)}`)
     if (Object.hasOwn(this.publishedTopics, name)) {
       const rosMessage = this.buildPublishMessage(name, payload)
       try {

--- a/src/robot_comms.js
+++ b/src/robot_comms.js
@@ -256,10 +256,6 @@ class RobotComms {
       }
 
       default: {
-        console.debug(
-          `buildPublishMessage: topic: ${topicName}, msgType: ${this.publishedTopics[topicName]}`
-        )
-
         const publishMessageClass = rclnodejs.createMessage(
           this.publishedTopics[topicName]
         )._refObject
@@ -282,9 +278,6 @@ class RobotComms {
           set(publishMessage, attribute, message[attribute])
         }
 
-        console.debug(
-          `buildPublishMessage: publishMessage: ${JSON.stringify(publishMessage, null, '  ')}`
-        )
         return publishMessage
       }
     }


### PR DESCRIPTION
Joystick widgets can now be removed from the UI, added, and reconfigured. Multiple joysticks can exist simultaneously. They can be configured to publish to a single topic and interface combination where two attributes of the message are populated with the x and y value. They can also be configured to replace mimic a simple slider and a servo slider. However, the joystick can only command a single servo and always returns the servo position to 0.

Added the lodash cloneDeep() function, so the robot_comms module could retrieve ROS message definitions at run-time.

Added specific documentation in README_joystick.md.
Changed the background color of the trash square, to make it obvious when a widget is about to be deleted.
TwistStamped message is no longer hard-coded in robot_comms.js. Joystick and Slider widgets support any defined message type now without a hard-coded definition.
Added the release_docs.sh script to deploy all README files to the registry server, as a form of documentation.


