### PR TITLE
Choose from multiple cameras

### DIFF
--- a/public/css/index.css
+++ b/public/css/index.css
@@ -48,6 +48,13 @@ input, select{
     color: #CC894E;
 }
 
+#chooseCamera {
+    width: 70px;
+}
+#chooseCamera option {
+    width: 20px;
+}
+
 #widgets{
     height: 100vh;
     font-family: 'Roboto', sans-serif;
@@ -141,7 +148,7 @@ input, select{
 #configure{
     cursor: pointer;
     position: absolute;
-    top: 5px;
+    top: 1px;
     left: 50%;
     transform: translate(-50%, 0%);
     z-index: 1;
@@ -164,8 +171,32 @@ input, select{
 #keyControl {
     cursor: pointer;
     position: absolute;
-    top: 5px;
-    left: 60%;
+    top: 1px;
+    left: 58%;
+    transform: translate(-50%, 0%);
+    z-index: 1;
+    text-align: center;
+    padding: 5px;
+    border: 1px solid #3392ff;
+    clip-path: polygon(
+        0 10%,
+        10% 0,
+        90% 0,
+        100% 10%,
+        100% 90%,
+        90% 100%,
+        10% 100%,
+        0% 90%,
+        0% 10%
+    )
+}
+
+#cameras {
+    cursor: pointer;
+    position: absolute;
+    top: 1px;
+    left: 65%;
+    width: 70px;
     transform: translate(-50%, 0%);
     z-index: 1;
     text-align: center;

--- a/public/index.htm
+++ b/public/index.htm
@@ -11,6 +11,13 @@
 <body>
     <div id="configure">CONFIGURE</div>
     <div id="keyControl">ENABLE KEYS</div>
+    <div id="cameras">
+      <form id="cameraForm">
+        <select id="chooseCamera" name="Camera">
+        </select>
+      </form>
+    </div>
+
     <div id="trash"></div>
     <div id="widgets"></div>
     <img id='mainImage'

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -54,10 +54,37 @@ const initSocket = function () {
   return objSocket
 }
 
+/**
+ * Remove any existing options from the chooseCamera dropdown
+ * menu and then add an option for each camera in cameras.
+ */
+const chooseCamera = function () {
+  jQuery('#chooseCamera')
+    .find('option')
+    .remove()
+
+  // TODO: Populate cameras with the list of actually available cameras
+  const cameras = ['camera0', 'camera1', 'camera2', 'camera3']
+  let nextOption = null
+  jQuery.each(cameras, function (i, camera) {
+    nextOption = jQuery('<option>', {
+      value: i,
+      text: camera
+    })
+    jQuery('#chooseCamera').append(nextOption)
+  })
+}
+
 jQuery(function () {
   const objSocket = initSocket()
 
   initWidgetConfig(objSocket)
+  chooseCamera()
+  jQuery('#chooseCamera').change(function () {
+    const newCamera = jQuery('#chooseCamera').find('option:selected').val()
+    console.debug(`chooseCamera: ${newCamera}`)
+    objSocket.emit('choose_camera', newCamera)
+  })
 
   /**
    * Save the configuration object. Called by clicking the "save config" button

--- a/public/js/rq_params.js
+++ b/public/js/rq_params.js
@@ -12,7 +12,7 @@
 
 const RQ_PARAMS = {}
 
-RQ_PARAMS.VERSION = '26'
+RQ_PARAMS.VERSION = '27'
 
 RQ_PARAMS.CONFIG_FORMAT_VERSION = '7'
 RQ_PARAMS.CONFIG_FILE = 'persist/configuration.json'

--- a/src/params.js
+++ b/src/params.js
@@ -8,7 +8,7 @@
 const path = require('path')
 
 const RQ_PARAMS = {}
-RQ_PARAMS.VERSION = '26'
+RQ_PARAMS.VERSION = '27'
 
 RQ_PARAMS.CONFIG_FORMAT_VERSION = '7'
 RQ_PARAMS.SERVER_STATIC_DIR = path.join(

--- a/src/robot_comms.js
+++ b/src/robot_comms.js
@@ -8,6 +8,8 @@ const rclnodejs = require('rclnodejs')
 const set = require('lodash.set')
 const cloneDeep = require('lodash.clonedeep')
 
+const DEFAULT_CAMERA = '0'
+
 /*
  * Attempted all of the following:
  * rclnodejs.createMessage(): missing hasMember()
@@ -76,6 +78,8 @@ class RobotComms {
     this.serviceClients = {}
     this.services = []
 
+    this.image_sub = null
+
     this.rclnodejs = rclnodejs
     this.rclnodejs.init()
     this.node = this.rclnodejs.createNode(this.nodeName)
@@ -138,9 +142,6 @@ class RobotComms {
    *                           or widgetConfig.data.serviceAttribute(s)
    */
   handle_payload (name, payload) {
-    console.debug(
-      `handle_payload: name: ${name}` +
-      `, payload: ${JSON.stringify(payload)}`)
     if (Object.hasOwn(this.publishedTopics, name)) {
       const rosMessage = this.buildPublishMessage(name, payload)
       try {
@@ -180,6 +181,8 @@ class RobotComms {
           this.logger.info('handle_payload: restart called')
         }
       )
+    } else if (name === 'choose_camera') {
+      this.choose_camera(payload)
     } else {
       this.logger.warn(`handle_payload(): ${name} not recognized as publish or service`)
     }
@@ -356,6 +359,37 @@ class RobotComms {
   }
 
   /**
+   * Used until a way is found to properly unsubscribe from a topic.
+   */
+  dummy_cb (msg) {
+  }
+
+  /**
+   * Subscribe to an image topic.
+   *
+   * @param {string} cameraId - the numerical ID of the camera
+   */
+  choose_camera (cameraId) {
+    if (this.image_sub) {
+      /*
+       * Delete this subscriber, so the messages stop flowing.
+       * Haven't found a better way to unsubscribe from a topic.
+       */
+      this.image_sub._callback = this.dummy_cb
+      delete this.image_sub
+      this.image_sub = null
+    }
+
+    this.logger.debug(`choose_camera: ${cameraId}`)
+    const cameraTopic = 'rq_camera_node' + cameraId + '/image_raw/compressed'
+    this.image_sub = this.node.createSubscription(
+      'sensor_msgs/msg/CompressedImage',
+      cameraTopic,
+      { history: 1, depth: 1 },
+      this.image_cb.bind(this))
+  }
+
+  /**
    * Setup the connections to the ROS graph. This includes the
    * creation of topic subscribers and publishers as well as service
    * clients.
@@ -367,15 +401,7 @@ class RobotComms {
   setup_ROS (widgetsConfig) {
     this.logger.info(`${this.nodeName} started`)
 
-    /*
-     * The image_sub subscriber isn't associated with any widget.
-     */
-    // TODO: Replace this with a call to create_subscriber()
-    this.image_sub = this.node.createSubscription(
-      'sensor_msgs/msg/CompressedImage',
-      'rq_camera_node/image_raw/compressed',
-      { history: 1, depth: 1 },
-      this.image_cb.bind(this))
+    this.choose_camera(DEFAULT_CAMERA)
 
     for (const widgetConfig of widgetsConfig) {
       this.logger.debug('Parsing widget ' + widgetConfig.type + ' ' + widgetConfig.label)
@@ -461,12 +487,6 @@ class RobotComms {
    * 'mainImage' event. The payload sent with the 'mainImage' emit must
    * be a complete JPEG encoding of the image, further encoded into a
    * base64 representation.
-   *
-   * The configuration of the image messages is controlled by the
-   * usb_cam/set_parameters service. The most useful parameters
-   * are:
-   * ['camera_name', 'framerate', 'image_width', 'image_height',
-   *  'image_raw.format', 'pixel_format', 'video_device']
    *
    * @param {CompressedImage} msg - The complete ROS image message
    */

--- a/src/robot_comms.js
+++ b/src/robot_comms.js
@@ -359,24 +359,13 @@ class RobotComms {
   }
 
   /**
-   * Used until a way is found to properly unsubscribe from a topic.
-   */
-  dummy_cb (msg) {
-  }
-
-  /**
    * Subscribe to an image topic.
    *
    * @param {string} cameraId - the numerical ID of the camera
    */
   choose_camera (cameraId) {
     if (this.image_sub) {
-      /*
-       * Delete this subscriber, so the messages stop flowing.
-       * Haven't found a better way to unsubscribe from a topic.
-       */
-      this.image_sub._callback = this.dummy_cb
-      delete this.image_sub
+      this.node.destroySubscription(this.image_sub)
       this.image_sub = null
     }
 

--- a/src/web_server.js
+++ b/src/web_server.js
@@ -15,10 +15,7 @@ class WebServer {
   constructor (clientName, configFile) {
     this.clientName = clientName
     this.configFile = configFile
-    /*
-     * update and restart aren't associated with any widget.
-     */
-    this.incomingEvents = ['update', 'restart']
+    this.incomingEvents = ['update', 'restart', 'choose_camera']
     this.send_to_robot = null
 
     this.express_app = express()


### PR DESCRIPTION
Added a dropdown menu to choose one from up to four connected cameras.

The default camera at startup is always camera 0. There are always four choices shown in the menu (0–3) but they may not all be available. If a camera is selected from the menu but that camera isn't available, the background image will remain as the last frame from the previous camera.

The selected camera can be disconnected at run-time and the background image will cease to update. The disconnected camera will remain in the menu until the robot is rebooted. A camera can be added at run-time but it won't update the background image until the robot is rebooted.

Requires [rq_core PR 64](https://github.com/billmania/roboquest_core/pull/64)