### PR TITLE
Added support for REBOOT and SHUTDOWN to the configuration menu

### DIFF
--- a/public/index.htm
+++ b/public/index.htm
@@ -32,8 +32,9 @@
     </div>
     <div id="menuDialog" title="Configuration Settings">
         <form id="menuForm">
-            <div class="menuButton" id="updateSoftware">update robot software</div>
-            <div class="menuButton" id="saveConfig">save config</div>
+            <div class="menuButton" id="updateSoftware">update software</div>
+            <div class="menuButton" id="rebootRobot">reboot</div>
+            <div class="menuButton" id="shutdownRobot">shutdown</div>
             <div class="menuButton" id="addWidget">add widget</div>
             <div class="menuButton" id="configKeys">config keys</div>
             <div class="menuButton" id="configServos">config servos</div>
@@ -47,6 +48,18 @@
     <div id="updateSoftwareDialog">
       <div id="updateSoftwareText">
         <ol id="updateSoftwareList" type="1">
+        </ol>
+      </div>
+    </div>
+    <div id="rebootRobotDialog">
+      <div id="rebootRobotText">
+        <ol id="rebootRobotList" type="1">
+        </ol>
+      </div>
+    </div>
+    <div id="shutdownRobotDialog">
+      <div id="shutdownRobotText">
+        <ol id="shutdownRobotList" type="1">
         </ol>
       </div>
     </div>
@@ -217,6 +230,7 @@
 <script src="./js/wGamepad.js"></script>
 <script src="./js/key_help.js"></script>
 <script src="./js/update_help.js"></script>
+<script src="./js/robot_help.js"></script>
 <script src="./js/key_control.js"></script>
 <script src="./js/servo_config.js"></script>
 <script src="./js/widget_config.js"></script>

--- a/public/js/robot_help.js
+++ b/public/js/robot_help.js
@@ -1,0 +1,25 @@
+'use strict'
+
+/**
+ * The preparation steps for doing stuff to the robot.
+ *
+ */
+
+const RQRebootHelp = {}
+
+RQRebootHelp.version = 1
+RQRebootHelp.steps = []
+RQRebootHelp.steps.push('Set the HAT UI to screen 4')
+RQRebootHelp.steps.push('Click the Reboot button')
+RQRebootHelp.steps.push('"reboot start" may appear on screen 4')
+RQRebootHelp.steps.push('Wait for the HAT UI to show only HAT setup')
+RQRebootHelp.steps.push('Reload the browser page')
+
+const RQShutdownHelp = {}
+
+RQShutdownHelp.version = 1
+RQShutdownHelp.steps = []
+RQShutdownHelp.steps.push('Set the HAT UI to screen 4')
+RQShutdownHelp.steps.push('Click the Shutdown button')
+RQShutdownHelp.steps.push('"shutdown start" may appear on screen 4')
+RQShutdownHelp.steps.push('Wait 20 seconds then manually remove power')

--- a/public/js/rq_params.js
+++ b/public/js/rq_params.js
@@ -12,7 +12,7 @@
 
 const RQ_PARAMS = {}
 
-RQ_PARAMS.VERSION = '30'
+RQ_PARAMS.VERSION = '31'
 
 RQ_PARAMS.CONFIG_FORMAT_VERSION = '8'
 RQ_PARAMS.CONFIG_FILE = 'persist/configuration.json'

--- a/src/params.js
+++ b/src/params.js
@@ -8,7 +8,7 @@
 const path = require('path')
 
 const RQ_PARAMS = {}
-RQ_PARAMS.VERSION = '30'
+RQ_PARAMS.VERSION = '31'
 
 RQ_PARAMS.CONFIG_FORMAT_VERSION = '8'
 RQ_PARAMS.SERVER_STATIC_DIR = path.join(


### PR DESCRIPTION
Depends upon [rq_core PR 70](https://github.com/billmania/roboquest_core/pull/70).

This feature requires two "update software" clicks. The first will cause the updater.py script to be updated. The second will actually update the rq_ui image.

Added two buttons to the configuration menu: Reboot and Shutdown. Both choices show a list of steps to complete the action.

Depending on precise timing, a message about the reboot or shutdown may appear on the HAT UI. For the shutdown, electrical power must still be manually disconnected from the robot. After the reboot, prudence dictates a manual reload of the browser page.

https://github.com/billmania/roboquest_ui/issues/113