### PR TITLE
Restored the "save config" button

### DIFF
--- a/public/index.htm
+++ b/public/index.htm
@@ -33,6 +33,7 @@
     <div id="menuDialog" title="Configuration Settings">
         <form id="menuForm">
             <div class="menuButton" id="updateSoftware">update software</div>
+            <div class="menuButton" id="saveConfig">save config</div>
             <div class="menuButton" id="rebootRobot">reboot</div>
             <div class="menuButton" id="shutdownRobot">shutdown</div>
             <div class="menuButton" id="addWidget">add widget</div>

--- a/public/js/rq_params.js
+++ b/public/js/rq_params.js
@@ -12,7 +12,7 @@
 
 const RQ_PARAMS = {}
 
-RQ_PARAMS.VERSION = '31'
+RQ_PARAMS.VERSION = '31.1'
 
 RQ_PARAMS.CONFIG_FORMAT_VERSION = '8'
 RQ_PARAMS.CONFIG_FILE = 'persist/configuration.json'

--- a/src/params.js
+++ b/src/params.js
@@ -8,7 +8,7 @@
 const path = require('path')
 
 const RQ_PARAMS = {}
-RQ_PARAMS.VERSION = '31'
+RQ_PARAMS.VERSION = '31.1'
 
 RQ_PARAMS.CONFIG_FORMAT_VERSION = '8'
 RQ_PARAMS.SERVER_STATIC_DIR = path.join(


### PR DESCRIPTION
In v31 the "save config" button was accidentally removed. This change restores that functionality.

Tested by clicking the "save config" button and confirming both the entry in the console log and the timestamp change on the configuration.json file.

https://github.com/billmania/roboquest_ui/issues/143