### PR TITLE
Basic support for Logitech F310 gamepad with Chrome

### DIFF
--- a/public/css/index.css
+++ b/public/css/index.css
@@ -249,6 +249,10 @@ input, select{
     )
 }
 
+/*
+ * This is obsolete, since it's no longer necessary to highlight
+ * gamepad configuration rows.
+ */
 .highlight-row {
         display: inline-block;
         padding: .25em 0;

--- a/public/index.htm
+++ b/public/index.htm
@@ -228,6 +228,7 @@
 <script src="./js/wIndicator.js"></script>
 <script src="./js/joy.min.js"></script>
 <script src="./js/wJoystick.js"></script>
+<script src="./js/gamepad_mapping.js"></script>
 <script src="./js/wGamepad.js"></script>
 <script src="./js/key_help.js"></script>
 <script src="./js/update_help.js"></script>

--- a/public/js/gamepad_mapping.js
+++ b/public/js/gamepad_mapping.js
@@ -1,0 +1,48 @@
+'use strict'
+
+/**
+ * Mapping the gamepad buttons and axes names to their type and index.
+ */
+
+/**
+ * An object to map button and axis indices to a descriptive name AND
+ * provide some information. If the entry in the 'buttons' and 'axes'
+ * array is a string, that's the descriptive name and the entry is to
+ * be treated like a simple button, ie. it has the 'pressed' property.
+ * If instead the entry is itself a 3 element array, then the first
+ * entry is the descriptive name, the second is the released value,
+ * and the third is the minimum value.
+ */
+const gamepadMaps = { // eslint-disable-line no-unused-vars
+  '©Microsoft Corporation Controller (STANDARD GAMEPAD Vendor: 045e Product: 028e)': {
+  },
+  '046d-c21d-Logitech Gamepad F310': { // Firefox
+  },
+  'Logitech Gamepad F310 (STANDARD GAMEPAD Vendor: 046d Product: c21d)': { // Chrome
+    b: [
+      'A',
+      'B',
+      'X',
+      'Y',
+      'Left index',
+      'Right index',
+      ['Left trigger', 0.0, 0.0],
+      ['Right trigger', 0.0, 0.0],
+      'Back',
+      'Start',
+      'Left joy press',
+      'Right joy press',
+      'Up HAT',
+      'Down HAT',
+      'Left HAT',
+      'Right HAT',
+      'Big'
+    ],
+    a: [
+      ['Left joy horiz', 0.0, -1.0],
+      ['Left joy vert', 0.0, -1.0],
+      ['Right joy horiz', 0.0, -1.0],
+      ['Right joy vert', 0.0, -1.0]
+    ]
+  }
+}

--- a/public/js/gamepad_mapping.js
+++ b/public/js/gamepad_mapping.js
@@ -15,8 +15,62 @@
  */
 const gamepadMaps = { // eslint-disable-line no-unused-vars
   '©Microsoft Corporation Controller (STANDARD GAMEPAD Vendor: 045e Product: 028e)': {
+    b: [
+      'A',
+      'B',
+      'Y',
+      'X',
+      'Left index',
+      'Right index',
+      'na',
+      'na',
+      'Back',
+      'Start',
+      'Left joy press',
+      'Right joy press',
+      'Up D-PAD',
+      'Down D-PAD',
+      'Left D-PAD',
+      'Right D-PAD',
+      'Big'
+    ],
+    a: [
+      ['Left joy horiz', 0.0, -1.0],
+      ['Left joy vert', 0.0, -1.0],
+      ['Right joy horiz', 0.0, -1.0],
+      ['Right joy vert', 0.0, -1.0],
+      ['Left trigger', -1.0, -1.0],
+      ['Right trigger', -1.0, -1.0]
+    ]
   },
-  '046d-c21d-Logitech Gamepad F310': { // Firefox
+  '046d-c21d-Logitech Gamepad F310': { // Firefox/ubuntu
+    b: [
+      'A',
+      'B',
+      'Y',
+      'X',
+      'Left index',
+      'Right index',
+      'na',
+      'na',
+      'Back',
+      'Start',
+      'Left joy press',
+      'Right joy press',
+      'Up D-PAD',
+      'Down D-PAD',
+      'Left D-PAD',
+      'Right D-PAD',
+      'Big'
+    ],
+    a: [
+      ['Left joy horiz', 0.0, -1.0],
+      ['Left joy vert', 0.0, -1.0],
+      ['Right joy horiz', 0.0, -1.0],
+      ['Right joy vert', 0.0, -1.0],
+      ['Left trigger', -1.0, -1.0],
+      ['Right trigger', -1.0, -1.0]
+    ]
   },
   'Logitech Gamepad F310 (STANDARD GAMEPAD Vendor: 046d Product: c21d)': { // Chrome/ubuntu
     b: [
@@ -32,10 +86,10 @@ const gamepadMaps = { // eslint-disable-line no-unused-vars
       'Start',
       'Left joy press',
       'Right joy press',
-      'Up HAT',
-      'Down HAT',
-      'Left HAT',
-      'Right HAT',
+      'Up D-PAD',
+      'Down D-PAD',
+      'Left D-PAD',
+      'Right D-PAD',
       'Big'
     ],
     a: [
@@ -59,10 +113,10 @@ const gamepadMaps = { // eslint-disable-line no-unused-vars
       'Start',
       'Left joy press',
       'Right joy press',
-      'Up HAT',
-      'Down HAT',
-      'Left HAT',
-      'Right HAT',
+      'Up D-PAD',
+      'Down D-PAD',
+      'Left D-PAD',
+      'Right D-PAD',
       'Big'
     ],
     a: [

--- a/public/js/gamepad_mapping.js
+++ b/public/js/gamepad_mapping.js
@@ -18,7 +18,34 @@ const gamepadMaps = { // eslint-disable-line no-unused-vars
   },
   '046d-c21d-Logitech Gamepad F310': { // Firefox
   },
-  'Logitech Gamepad F310 (STANDARD GAMEPAD Vendor: 046d Product: c21d)': { // Chrome
+  'Logitech Gamepad F310 (STANDARD GAMEPAD Vendor: 046d Product: c21d)': { // Chrome/ubuntu
+    b: [
+      'A',
+      'B',
+      'X',
+      'Y',
+      'Left index',
+      'Right index',
+      ['Left trigger', 0.0, 0.0],
+      ['Right trigger', 0.0, 0.0],
+      'Back',
+      'Start',
+      'Left joy press',
+      'Right joy press',
+      'Up HAT',
+      'Down HAT',
+      'Left HAT',
+      'Right HAT',
+      'Big'
+    ],
+    a: [
+      ['Left joy horiz', 0.0, -1.0],
+      ['Left joy vert', 0.0, -1.0],
+      ['Right joy horiz', 0.0, -1.0],
+      ['Right joy vert', 0.0, -1.0]
+    ]
+  },
+  'Xbox 360 Controller (XInput STANDARD GAMEPAD)': { // Chrome/Windows
     b: [
       'A',
       'B',

--- a/public/js/rq_params.js
+++ b/public/js/rq_params.js
@@ -12,7 +12,7 @@
 
 const RQ_PARAMS = {}
 
-RQ_PARAMS.VERSION = '31.1'
+RQ_PARAMS.VERSION = '32rc1'
 
 RQ_PARAMS.CONFIG_FORMAT_VERSION = '8'
 RQ_PARAMS.CONFIG_FILE = 'persist/configuration.json'

--- a/public/js/wGamepad.js
+++ b/public/js/wGamepad.js
@@ -743,10 +743,20 @@ class Gamepad {
   enableGamepad () {
     if (!this.gamepadConnected()) {
       console.warn('enableGamepad: no gamepad to enable')
+      this.disableGamepad()
       return
     }
 
-    this.disableGamepad()
+    if (this._gamepadEnabled) {
+      console.warn('enableGamepad: gamepad already enabled')
+      return
+    }
+
+    if (this._pollIntervalId) {
+      clearInterval(this._pollIntervalId)
+      this._pollIntervalId = null
+    }
+
     this._pollIntervalId = setInterval(
       this._pollGamepad.bind(this),
       RQ_PARAMS.POLL_PERIOD_MS

--- a/public/js/wGamepad.js
+++ b/public/js/wGamepad.js
@@ -374,39 +374,13 @@ class Gamepad {
   }
 
   /**
-   * Highlight a specific row in the table of axes and buttons
-   * configuration. All other highlights will be removed.
-   *
-   * @param {string} rowPrefix - the prefix part of the HTML element
-   *                             ID which identifies the row
-   * @param {number} rowIndex - the index part of the HTML element
-   *                            ID which identifies the row
-   */
-  _highlightConfigRow (rowPrefix, rowIndex) {
-    const HighLightRowClass = 'highlight-row'
-    const paddedIndex = rowIndex.toString().padStart(PAD_LENGTH, '0')
-
-    const configRow = jQuery(`#${rowPrefix}${paddedIndex}span`)
-    jQuery('.' + HighLightRowClass).removeClass(HighLightRowClass)
-    configRow.addClass(HighLightRowClass)
-  }
-
-  /**
    * Check the gamepad object for activated buttons and axes. More
    * than one button and more than one axis can be active per poll.
-   * This _pollGamepad method is used for two purposes.
    *
-   * The first is when configuring the gamepad. Each active (pressed)
-   * button and each active axis causes its corresponding Gamepad widget
-   * configuration row to be highlight. Only one row at a time can be
-   * highlighted, so the last active button/axis row wins. Buttons are
-   * examined first and axes second.
-   *
-   * The second is when the gamepad is enabled and not being configured
-   * (using the global variable configuringWidget for the latter).
-   * During this scenario, this._actionMap is used to determine which
-   * gamepad actions to examine and pass along to the gamepad widget
-   * for further processing.
+   * When the gamepad is enabled and not being configured
+   * (using the global variable configuringWidget for the latter),
+   * this._actionMap is used to determine which gamepad actions to examine
+   * and pass along to the gamepad widget for further processing.
    *
    * The current state of an action included in this._actionMap is sent
    * to the widget's valuesHandler() every RQ_PARAMS.POLL_PERIOD_MS,
@@ -461,13 +435,6 @@ class Gamepad {
             data: this._actionMap[PREFIX_MAP[BUTTON_PREFIX]][bIndex]
           })
         }
-      } else {
-        if (this._gamepad.buttons[bIndex].pressed) {
-          this._highlightConfigRow(
-            BUTTON_PREFIX,
-            bIndex
-          )
-        }
       }
     }
 
@@ -484,13 +451,6 @@ class Gamepad {
             value,
             data: this._actionMap[PREFIX_MAP[AXIS_PREFIX]][aIndex]
           })
-        }
-      } else {
-        if (this._gamepad.axes[aIndex]) {
-          this._highlightConfigRow(
-            AXIS_PREFIX,
-            aIndex
-          )
         }
       }
     }
@@ -562,7 +522,8 @@ class Gamepad {
   }
 
   /**
-   * This method can't be called until a gamepad is connected.
+   * This method can't be called until a gamepad is connected, because
+   * the ID of the gamepad is required.
    *
    * Enumerate the buttons and axes from GamepadMaps and build the
    * configuration input form. The gamepad widget can publish to zero or

--- a/public/js/wGamepad.js
+++ b/public/js/wGamepad.js
@@ -36,15 +36,19 @@ const WINDOWS = 'windows'
  * The first element of each entry is the field name and is hard-coded
  * into the GamepadData class.
  * The second is a list of default values for a pulldown menu.
+ * The third is a default value for the field, without a pulldown.
  */
 const ACTION_FIELDS = [
-  ['description', []], // meaningful to the user
-  ['destinationType', ['topic', 'service']], // topic or service
-  ['destinationName', []], // name of topic or service
-  ['interface', []], // interface type
-  ['attributes', []], // semi-colon delimited list with colon-delimited constants
-  ['scaling', ['1.0']] // signed, floating point
+  ['description', [], ''], // meaningful to the user
+  ['destinationType', ['topic', 'service'], ''], // topic or service
+  ['destinationName', [], ''], // name of topic or service
+  ['interface', [], ''], // interface type
+  ['attributes', [], ''], // semi-colon delimited list with colon-delimited constants
+  ['scaling', [], '1.0'] // signed, floating point
 ]
+const FIELD_NAME = 0
+const FIELD_PULLDOWN = 1
+const FIELD_DEFAULT = 2
 
 /*
  * 'buttons' and 'axes' come from the Gamepad object.
@@ -582,7 +586,18 @@ class Gamepad {
         row += '</span>'
         row += '</label></td>'
         for (const field of ACTION_FIELDS) {
-          row += `<td><input type="text" data-section="data" value="" name="${section.prefix}${indexId}${field[0]}"></td>`
+          if (field.length > 1 &&
+              Array.isArray(field[FIELD_PULLDOWN]) &&
+              field[FIELD_PULLDOWN].length > 0) {
+            row += `<td><select data-section="data" value="" name="${section.prefix}${indexId}${field[0]}">`
+            row += '<option value=""></option>'
+            for (const value of field[FIELD_PULLDOWN]) {
+              row += `<option value="${value}">${value}</option>`
+            }
+            row += '</select></td>'
+          } else {
+            row += `<td><input type="text" data-section="data" value="" name="${section.prefix}${indexId}${field[0]}"></td>`
+          }
         }
         row += '</tr>'
         gamepadInputsTable.append(row)

--- a/public/js/wGamepad.js
+++ b/public/js/wGamepad.js
@@ -33,15 +33,17 @@ const WINDOWS = 'windows'
  * The gamepad widget configuration dialog data section has a
  * form containing a table which includes rows with the following
  * fields.
- * These names are hard-coded into the GamepadData class.
+ * The first element of each entry is the field name and is hard-coded
+ * into the GamepadData class.
+ * The second is a list of default values for a pulldown menu.
  */
 const ACTION_FIELDS = [
-  'description', // meaningful to the user
-  'destinationType', // topic or service
-  'destinationName', // name of topic or service
-  'interface', // interface type
-  'attributes', // semi-colon delimited list with colon-delimited constants
-  'scaling' // signed, floating point
+  ['description', []], // meaningful to the user
+  ['destinationType', ['topic', 'service']], // topic or service
+  ['destinationName', []], // name of topic or service
+  ['interface', []], // interface type
+  ['attributes', []], // semi-colon delimited list with colon-delimited constants
+  ['scaling', ['1.0']] // signed, floating point
 ]
 
 /*
@@ -535,7 +537,7 @@ class Gamepad {
     jQuery('#gamepadId').html(this._gamepad.id)
     let columnHeadings = '<tr><th>actionId</th>'
     for (const field of ACTION_FIELDS) {
-      columnHeadings += `<th>${field}</th>`
+      columnHeadings += `<th>${field[0]}</th>`
     }
     columnHeadings += '</tr>'
 
@@ -580,7 +582,7 @@ class Gamepad {
         row += '</span>'
         row += '</label></td>'
         for (const field of ACTION_FIELDS) {
-          row += `<td><input type="text" data-section="data" value="" name="${section.prefix}${indexId}${field}"></td>`
+          row += `<td><input type="text" data-section="data" value="" name="${section.prefix}${indexId}${field[0]}"></td>`
         }
         row += '</tr>'
         gamepadInputsTable.append(row)

--- a/public/js/widget_config.js
+++ b/public/js/widget_config.js
@@ -234,15 +234,15 @@ const openConfigureWidgetDialog = function (widget) {
     open: function (event, ui) {
       keyControl.disableKeys()
       configuringWidget = true
-      gamepad.enableGamepad()
+      console.debug('configuringWidget is true')
     },
     close: function (event, ui) {
       /*
        * Executed by clicking the X or Cancel on the (re)Configure Widget
        * dialog, regardless of widget type. Also by calling dialog.close().
        */
-      gamepad.disableGamepad()
       configuringWidget = false
+      console.debug('configuringWidget is false')
     }
   }).dialog('open')
 }
@@ -324,7 +324,6 @@ const reconfigureWidget = function (oldWidgetConfig, newWidgetConfig) {
       `${newWidgetConfig.id} must have` +
       ' a unique, non-blank label.'
     )
-
 
     return
   }
@@ -618,6 +617,7 @@ const initWidgetConfig = function (objSocket) { // eslint-disable-line no-unused
 
     createWidget(objNewWidget)
     configuringWidget = false
+    console.debug('configuringWidget is false')
     positionWidgets()
   }
 
@@ -670,7 +670,7 @@ const initWidgetConfig = function (objSocket) { // eslint-disable-line no-unused
         keyControl.disableKeys()
         setWidgetConfigDefaults()
         configuringWidget = true
-        gamepad.enableGamepad()
+        console.debug('configuringWidget is true')
       },
       close: function (event, ui) {
         gamepad.disableGamepad()

--- a/src/params.js
+++ b/src/params.js
@@ -8,7 +8,7 @@
 const path = require('path')
 
 const RQ_PARAMS = {}
-RQ_PARAMS.VERSION = '31.1'
+RQ_PARAMS.VERSION = '32rc1'
 
 RQ_PARAMS.CONFIG_FORMAT_VERSION = '8'
 RQ_PARAMS.SERVER_STATIC_DIR = path.join(


### PR DESCRIPTION
Added better definitions for each browser, including using the names of the buttons and axes.

Tested with Chrome on ubuntu and Windows. Did not test the functionality of the triggers when they're handled as buttons.