### PR TITLE
Changed the data type of gamepad scaling from Int to Float

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>roboquest_ui</name>
-  <version>32.0.0</version>
+  <version>35.1.0</version>
   <description>RoboQuest browser-based UI</description>
   <maintainer email="bill@manialabs.us">Bill Mania</maintainer>
   <license>Proprietary</license>

--- a/public/js/rq_params.js
+++ b/public/js/rq_params.js
@@ -12,7 +12,7 @@
 
 const RQ_PARAMS = {}
 
-RQ_PARAMS.VERSION = '35'
+RQ_PARAMS.VERSION = '35.1'
 
 RQ_PARAMS.CONFIG_FORMAT_VERSION = '8'
 RQ_PARAMS.CONFIG_FILE = 'persist/configuration.json'

--- a/public/js/wGamepad.js
+++ b/public/js/wGamepad.js
@@ -165,7 +165,7 @@ class GamepadData { // eslint-disable-line no-unused-vars
             .split(RQ_PARAMS.ATTR_DELIMIT)
           parsed = attributes
         } else {
-          parsed = [parseInt(elementValue)]
+          parsed = [parseFloat(elementValue)]
         }
         if (this._dataObject.topicDirection) {
           this._dataObject.scale = parsed

--- a/src/params.js
+++ b/src/params.js
@@ -8,7 +8,7 @@
 const path = require('path')
 
 const RQ_PARAMS = {}
-RQ_PARAMS.VERSION = '35'
+RQ_PARAMS.VERSION = '35.1'
 
 RQ_PARAMS.CONFIG_FORMAT_VERSION = '8'
 RQ_PARAMS.SERVER_STATIC_DIR = path.join(


### PR DESCRIPTION
[RQ_ui Issue 156](https://github.com/billmania/roboquest_ui/issues/156)
Required by [rq_core PR 90](https://github.com/billmania/roboquest_core/pull/90)

More accurate scaling of the gamepad joystick values is required to fully exploit the more accurate population of Twist messages, sent by the UI.