### PR TITLE
Disable the UI joystick widget when the gamepad is enabled

### DIFF
--- a/public/js/wGamepad.js
+++ b/public/js/wGamepad.js
@@ -1,7 +1,8 @@
 'use strict'
 /* global jQuery, RQ_PARAMS, configuringWidget, gamepadMaps */
 /* global DONT_SCALE, DEFAULT_VALUE */
-/* global assignValue ros */
+/* global assignValue, ros */
+/* global joystickIntervalDisabled */
 
 /**
  * A widget to represent a single gamepad. Only the most
@@ -527,7 +528,7 @@ class Gamepad {
       return
     }
 
-    if (!this._gamepad.connected) {
+    if (!this._gamepad || !this._gamepad.connected) {
       if (configuringWidget) {
         console.warn(
           'gamepad not connected, cannot configure'
@@ -1035,6 +1036,7 @@ class Gamepad {
       this._pollIntervalId = null
     }
     this._gamepadEnabled = false
+    joystickIntervalDisabled = false
     jQuery(`#${this.widgetId} .ui-button`).text(DISABLED_TEXT)
   }
 
@@ -1065,6 +1067,7 @@ class Gamepad {
       RQ_PARAMS.POLL_PERIOD_MS
     )
     this._gamepadEnabled = true
+    joystickIntervalDisabled = true
     jQuery(`#${this.widgetId} .ui-button`).text(ENABLED_TEXT)
   }
 

--- a/public/js/wJoystick.js
+++ b/public/js/wJoystick.js
@@ -9,6 +9,12 @@ const JOYSTICK_DEFAULT_SCALING = [1.0, 1.0]
  */
 const joystickIntervalId = {}
 
+/*
+ * Other functions may disable the joystick's interval, in order to prevent
+ * interference. Setting this flag does NOT disable the joystick.
+ */
+var joystickIntervalDisabled = false
+
 /**
  * A joystick for providing two values based on the position of the joystick
  * knob. Typically used to drive the robot. The x-axis value is always
@@ -153,10 +159,16 @@ jQuery.widget(RQ_PARAMS.WIDGET_NAMESPACE + '.JOYSTICK', {
             this.options.skipAnInterval = false
             return
           }
+          if (joystickIntervalDisabled) {
+            return
+          }
+
           this._triggerSocketEvent(null, this.options.currentAxes)
         },
         this.options.data.topicPeriodS * 1000
       )
+
+      joystickIntervalDisabled = false
     }
   },
 


### PR DESCRIPTION
The joystick UI widget has an interval on which it automatically publishes the current values from the joystick. When the gamepad is enabled and used to control the robot motion, the smoothness of the motion was being impacted, albeit mildly, because every three seconds the joystick was still commanding speeds of 0.

That bug was corrected and the joystick UI widget will now stop automatically publishing those zero speeds when the gamepad is enabled. Once the gamepad is disabled, the joystick resuming the automatic publishing.

https://github.com/billmania/roboquest_ui/issues/162