### PR TITLE
Gamepad D-PAD resets values when released

### DIFF
--- a/src/robot_comms.js
+++ b/src/robot_comms.js
@@ -207,6 +207,19 @@ class RobotComms {
       throw new Error(`${destinationName} not in interfacesMap`)
     }
 
+    if (Object.hasOwn(rosMessage, 'reset') &&
+        typeof rosMessage.reset === 'function') {
+      try {
+        rosMessage.reset()
+      } catch (error) {
+        this.logger.warn(
+          `getRosMessage: ${destinationName} reset() error ${error}`
+        )
+      }
+    } else {
+      this.logger.warn(`getRosMessage: ${destinationName} object doesn't have reset()`)
+    }
+
     return rosMessage
   }
 

--- a/src/ros_interfaces.js
+++ b/src/ros_interfaces.js
@@ -263,11 +263,11 @@ module.exports = {
       set_motors: '',
       set_servos: '',
       reset: function () {
-        this.set_charger = ''
-        this.set_fet1 = ''
-        this.set_fet2 = ''
-        this.set_motors = ''
-        this.set_servos = ''
+        this.set_charger = 'IGNORE'
+        this.set_fet1 = 'IGNORE'
+        this.set_fet2 = 'IGNORE'
+        this.set_motors = 'IGNORE'
+        this.set_servos = 'IGNORE'
       }
     }
   },

--- a/src/ros_interfaces.js
+++ b/src/ros_interfaces.js
@@ -46,6 +46,18 @@ module.exports = {
           y: 0.0,
           z: 0.0
         }
+      },
+      reset: function () {
+        this.header.stamp.sec = 0
+        this.header.stamp.nanosec = 0
+        this.header.frame_id = ''
+
+        this.twist.linear.x = 0.0
+        this.twist.linear.y = 0.0
+        this.twist.linear.z = 0.0
+        this.twist.angular.x = 0.0
+        this.twist.angular.y = 0.0
+        this.twist.angular.z = 0.0
       }
     },
 
@@ -57,7 +69,14 @@ module.exports = {
         },
         frame_id: ''
       },
-      max_rpm: 0
+      max_rpm: 0,
+      reset: function () {
+        this.header.stamp.sec = 0
+        this.header.stamp.nanosec = 0
+        this.header.frame_id = ''
+
+        this.max_rpm = 0
+      }
     },
 
     'rq_msgs/msg/Servos': {
@@ -163,7 +182,78 @@ module.exports = {
         angle_incr_deg: 0,
         speed_dps: 0,
         command_type: 0
+      },
+      reset: function () {
+        this.header.stamp.sec = 0
+        this.header.stamp.nanosec = 0
+        this.header.frame_id = ''
+
+        this.servo0.angle_deg = 0
+        this.servo0.angle_incr_deg = 0
+        this.servo0.speed_dps = 0
+        this.servo0.command_type = 0
+        this.servo1.angle_deg = 0
+        this.servo1.angle_incr_deg = 0
+        this.servo1.speed_dps = 0
+        this.servo1.command_type = 0
+        this.servo2.angle_deg = 0
+        this.servo2.angle_incr_deg = 0
+        this.servo2.speed_dps = 0
+        this.servo2.command_type = 0
+        this.servo3.angle_deg = 0
+        this.servo3.angle_incr_deg = 0
+        this.servo3.speed_dps = 0
+        this.servo3.command_type = 0
+        this.servo4.angle_deg = 0
+        this.servo4.angle_incr_deg = 0
+        this.servo0.speed_dps = 0
+        this.servo4.command_type = 0
+        this.servo5.angle_deg = 0
+        this.servo5.angle_incr_deg = 0
+        this.servo5.speed_dps = 0
+        this.servo5.command_type = 0
+        this.servo6.angle_deg = 0
+        this.servo6.angle_incr_deg = 0
+        this.servo6.speed_dps = 0
+        this.servo6.command_type = 0
+        this.servo7.angle_deg = 0
+        this.servo7.angle_incr_deg = 0
+        this.servo7.speed_dps = 0
+        this.servo7.command_type = 0
+        this.servo8.angle_deg = 0
+        this.servo8.angle_incr_deg = 0
+        this.servo8.speed_dps = 0
+        this.servo8.command_type = 0
+        this.servo9.angle_deg = 0
+        this.servo9.angle_incr_deg = 0
+        this.servo9.speed_dps = 0
+        this.servo9.command_type = 0
+        this.servo10.angle_deg = 0
+        this.servo10.angle_incr_deg = 0
+        this.servo10.speed_dps = 0
+        this.servo10.command_type = 0
+        this.servo11.angle_deg = 0
+        this.servo11.angle_incr_deg = 0
+        this.servo11.speed_dps = 0
+        this.servo11.command_type = 0
+        this.servo12.angle_deg = 0
+        this.servo12.angle_incr_deg = 0
+        this.servo12.speed_dps = 0
+        this.servo12.command_type = 0
+        this.servo13.angle_deg = 0
+        this.servo13.angle_incr_deg = 0
+        this.servo13.speed_dps = 0
+        this.servo13.command_type = 0
+        this.servo14.angle_deg = 0
+        this.servo14.angle_incr_deg = 0
+        this.servo14.speed_dps = 0
+        this.servo14.command_type = 0
+        this.servo15.angle_deg = 0
+        this.servo15.angle_incr_deg = 0
+        this.servo15.speed_dps = 0
+        this.servo15.command_type = 0
       }
+
     },
 
     'rq_msgs/srv/Control': {
@@ -171,7 +261,14 @@ module.exports = {
       set_fet1: '',
       set_fet2: '',
       set_motors: '',
-      set_servos: ''
+      set_servos: '',
+      reset: function () {
+        this.set_charger = ''
+        this.set_fet1 = ''
+        this.set_fet2 = ''
+        this.set_motors = ''
+        this.set_servos = ''
+      }
     }
   },
 


### PR DESCRIPTION
D-PAD can be used to set a specific angle of a servo. It's not able to use angle_incr_deg or speed_dps.

For example, the following example sets three different positions of a servo, using three D-PAD buttons.

**For this fix to take effect, /opt/persist/ui/ros_interfaces.js and
/opt/persist/ui/widget_interfaces.js must be removed and then the robot rebooted.**

```
        {
          "row": "b12",
          "name": "Pan center",
          "topicDirection": "publish",
          "topic": "servos",
          "topicType": "rq_msgs/msg/Servos",
          "topicAttribute": [
            "servo1.angle_deg:90",
            "servo1.command_type:1",
            "header.frame_id:up"
          ],
          "scale": [
            1
          ]
        },
```

